### PR TITLE
Include AlfredTelemetryHealthReporter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,5 @@ gradle-app.setting
 
 # # Work around https://youtrack.jetbrains.com/issue/IDEA-116898
 # gradle/wrapper/gradle-wrapper.properties
+
+**/alfresco.log

--- a/README.md
+++ b/README.md
@@ -126,6 +126,25 @@ from Alfresco's `DictionaryService`.
 
 ### HealthReporter implementations
 
+#### Alfred Telemetry
+
+Activation property: `eu.xenit.alfresco.healthprocessor.reporter.alfred-telemetry.enabled=true`
+
+Integration with [Alfred Telemetry](https://github.com/xenit-eu/alfred-telemetry) that can be used to expose 
+HealthProcessor metrics to various monitoring systems. 
+
+Exposed metrics:
+
+* `health-processor.active`  
+  Available tags: /  
+  A gauge with value 0 or 1, indicating if the reporter and hence by extension the Health-Processor is active
+* `health-processor.plugins`  
+  Available tags: /  
+  A gauge indicating the number of active `HealthProcessorPlugin` implementations. 
+* `health-processor.reports`  
+  Available tags: `status`  (HEALTHY, UNHEALTHY or NONE), `plugin` (the class name of the HealthProcessorPlugin implementation).  
+  A counter indicating the total number of processed reports, with the specific status and plugin as tag values. 
+
 #### Logging
 
 Activation property: `eu.xenit.alfresco.healthprocessor.reporter.log.summary.enabled=true`

--- a/alfresco-health-processor-platform/build.gradle
+++ b/alfresco-health-processor-platform/build.gradle
@@ -24,6 +24,7 @@ dependencies {
     alfrescoProvided("org.alfresco:alfresco-repository") {
         exclude module: 'spring-social-facebook-web'
     }
+    alfrescoProvided "io.micrometer:micrometer-core:${micrometerVersion}"
     implementation 'com.google.guava:guava:30.1-jre'
 
     testCompileOnly "org.projectlombok:lombok:${lombokVersion}"

--- a/alfresco-health-processor-platform/src/main/amp/config/alfresco/subsystems/HealthProcessor/default/heathprocessor.properties
+++ b/alfresco-health-processor-platform/src/main/amp/config/alfresco/subsystems/HealthProcessor/default/heathprocessor.properties
@@ -16,4 +16,5 @@ eu.xenit.alfresco.healthprocessor.plugin.noop.enabled=false
 eu.xenit.alfresco.healthprocessor.plugin.content-validation.enabled=false
 eu.xenit.alfresco.healthprocessor.plugin.content-validation.properties=
 
+eu.xenit.alfresco.healthprocessor.reporter.alfred-telemetry.enabled=false
 eu.xenit.alfresco.healthprocessor.reporter.log.summary.enabled=false

--- a/alfresco-health-processor-platform/src/main/amp/config/alfresco/subsystems/HealthProcessor/default/reporter-context.xml
+++ b/alfresco-health-processor-platform/src/main/amp/config/alfresco/subsystems/HealthProcessor/default/reporter-context.xml
@@ -8,5 +8,9 @@
             class="eu.xenit.alfresco.healthprocessor.reporter.SummaryLoggingHealthReporter">
         <property name="enabled" value="${eu.xenit.alfresco.healthprocessor.reporter.log.summary.enabled}"/>
     </bean>
+    <bean id="eu.xenit.alfresco.healthprocessor.reporter.telemetry.AlfredTelemetryHealthReporter"
+            class="eu.xenit.alfresco.healthprocessor.reporter.telemetry.AlfredTelemetryHealthReporterFactoryBean">
+        <property name="enabled" value="${eu.xenit.alfresco.healthprocessor.reporter.alfred-telemetry.enabled}"/>
+    </bean>
 
 </beans>

--- a/alfresco-health-processor-platform/src/main/java/eu/xenit/alfresco/healthprocessor/reporter/api/DisabledHealthReporter.java
+++ b/alfresco-health-processor-platform/src/main/java/eu/xenit/alfresco/healthprocessor/reporter/api/DisabledHealthReporter.java
@@ -1,0 +1,17 @@
+package eu.xenit.alfresco.healthprocessor.reporter.api;
+
+import eu.xenit.alfresco.healthprocessor.plugins.api.HealthProcessorPlugin;
+import java.util.Set;
+
+public final class DisabledHealthReporter implements HealthReporter {
+
+    @Override
+    public boolean isEnabled() {
+        return false;
+    }
+
+    @Override
+    public void processReports(Set<NodeHealthReport> reports, Class<? extends HealthProcessorPlugin> pluginClass) {
+
+    }
+}

--- a/alfresco-health-processor-platform/src/main/java/eu/xenit/alfresco/healthprocessor/reporter/api/DisabledHealthReporter.java
+++ b/alfresco-health-processor-platform/src/main/java/eu/xenit/alfresco/healthprocessor/reporter/api/DisabledHealthReporter.java
@@ -12,6 +12,6 @@ public final class DisabledHealthReporter implements HealthReporter {
 
     @Override
     public void processReports(Set<NodeHealthReport> reports, Class<? extends HealthProcessorPlugin> pluginClass) {
-
+        throw new UnsupportedOperationException("The DisabledHealthReporter shouldn't process reports");
     }
 }

--- a/alfresco-health-processor-platform/src/main/java/eu/xenit/alfresco/healthprocessor/reporter/api/HealthReporter.java
+++ b/alfresco-health-processor-platform/src/main/java/eu/xenit/alfresco/healthprocessor/reporter/api/HealthReporter.java
@@ -7,10 +7,18 @@ public interface HealthReporter {
 
     boolean isEnabled();
 
-    void onStart();
+    default void onStart() {
+
+    }
 
     void processReports(Set<NodeHealthReport> reports, Class<? extends HealthProcessorPlugin> pluginClass);
 
-    void onStop();
+    default void onStop() {
+
+    }
+
+    static HealthReporter DISABLED() {
+        return new DisabledHealthReporter();
+    }
 
 }

--- a/alfresco-health-processor-platform/src/main/java/eu/xenit/alfresco/healthprocessor/reporter/api/HealthReporter.java
+++ b/alfresco-health-processor-platform/src/main/java/eu/xenit/alfresco/healthprocessor/reporter/api/HealthReporter.java
@@ -17,7 +17,7 @@ public interface HealthReporter {
 
     }
 
-    static HealthReporter DISABLED() {
+    static HealthReporter disabled() {
         return new DisabledHealthReporter();
     }
 

--- a/alfresco-health-processor-platform/src/main/java/eu/xenit/alfresco/healthprocessor/reporter/telemetry/AlfredTelemetryHealthReporter.java
+++ b/alfresco-health-processor-platform/src/main/java/eu/xenit/alfresco/healthprocessor/reporter/telemetry/AlfredTelemetryHealthReporter.java
@@ -16,8 +16,10 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
+import lombok.EqualsAndHashCode;
 import lombok.Value;
 
+@EqualsAndHashCode(callSuper = true)
 public class AlfredTelemetryHealthReporter extends SingleReportHealthReporter {
 
     private final AtomicBoolean isActive = new AtomicBoolean(false);

--- a/alfresco-health-processor-platform/src/main/java/eu/xenit/alfresco/healthprocessor/reporter/telemetry/AlfredTelemetryHealthReporter.java
+++ b/alfresco-health-processor-platform/src/main/java/eu/xenit/alfresco/healthprocessor/reporter/telemetry/AlfredTelemetryHealthReporter.java
@@ -1,0 +1,75 @@
+package eu.xenit.alfresco.healthprocessor.reporter.telemetry;
+
+import eu.xenit.alfresco.healthprocessor.plugins.api.HealthProcessorPlugin;
+import eu.xenit.alfresco.healthprocessor.reporter.api.NodeHealthReport;
+import eu.xenit.alfresco.healthprocessor.reporter.api.NodeHealthStatus;
+import eu.xenit.alfresco.healthprocessor.reporter.api.SingleReportHealthReporter;
+import eu.xenit.alfresco.healthprocessor.reporter.telemetry.Constants.Description;
+import eu.xenit.alfresco.healthprocessor.reporter.telemetry.Constants.Key;
+import eu.xenit.alfresco.healthprocessor.reporter.telemetry.Constants.Tag;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Metrics;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+import lombok.Value;
+
+public class AlfredTelemetryHealthReporter extends SingleReportHealthReporter {
+
+    private final AtomicBoolean isActive = new AtomicBoolean(false);
+    private final Set<Class<? extends HealthProcessorPlugin>> plugins = new HashSet<>();
+
+    private final Map<ReportCounterKey, Counter> reportCounters = new HashMap<>();
+
+    private final MeterRegistry registry;
+
+    public AlfredTelemetryHealthReporter() {
+        this(Metrics.globalRegistry);
+    }
+
+    public AlfredTelemetryHealthReporter(MeterRegistry registry) {
+        this.registry = registry;
+
+        Gauge.builder(Key.ACTIVE, isActive, b -> b.get() ? 1d : 0d)
+                .register(registry);
+        Gauge.builder(Key.PLUGINS, plugins, Set::size)
+                .description(Description.PLUGINS)
+                .register(registry);
+    }
+
+    @Override
+    public void onStart() {
+        isActive.set(true);
+    }
+
+    @Override
+    public void onStop() {
+        isActive.set(false);
+    }
+
+    @Override
+    protected void processReport(NodeHealthReport report, Class<? extends HealthProcessorPlugin> pluginClass) {
+        plugins.add(pluginClass);
+        reportCounters.computeIfAbsent(new ReportCounterKey(pluginClass, report.getStatus()), this::createCounter)
+                .increment();
+    }
+
+    private Counter createCounter(ReportCounterKey key) {
+        return Counter.builder(Key.REPORTS)
+                .tag(Tag.PLUGIN, key.getPluginClass().getSimpleName())
+                .tag(Tag.STATUS, key.getStatus().name())
+                .register(registry);
+    }
+
+    @Value
+    private static class ReportCounterKey {
+
+        Class<? extends HealthProcessorPlugin> pluginClass;
+        NodeHealthStatus status;
+
+    }
+}

--- a/alfresco-health-processor-platform/src/main/java/eu/xenit/alfresco/healthprocessor/reporter/telemetry/AlfredTelemetryHealthReporterFactoryBean.java
+++ b/alfresco-health-processor-platform/src/main/java/eu/xenit/alfresco/healthprocessor/reporter/telemetry/AlfredTelemetryHealthReporterFactoryBean.java
@@ -42,6 +42,6 @@ public class AlfredTelemetryHealthReporterFactoryBean extends AbstractFactoryBea
             log.warn("{} enabled but Micrometer not found on the classpath. Is Alfred Telemetry installed?",
                     AlfredTelemetryHealthReporter.class.getSimpleName());
         }
-        return HealthReporter.DISABLED();
+        return HealthReporter.disabled();
     }
 }

--- a/alfresco-health-processor-platform/src/main/java/eu/xenit/alfresco/healthprocessor/reporter/telemetry/AlfredTelemetryHealthReporterFactoryBean.java
+++ b/alfresco-health-processor-platform/src/main/java/eu/xenit/alfresco/healthprocessor/reporter/telemetry/AlfredTelemetryHealthReporterFactoryBean.java
@@ -1,0 +1,47 @@
+package eu.xenit.alfresco.healthprocessor.reporter.telemetry;
+
+import eu.xenit.alfresco.healthprocessor.reporter.api.HealthReporter;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.config.AbstractFactoryBean;
+import org.springframework.util.ClassUtils;
+
+@Slf4j
+public class AlfredTelemetryHealthReporterFactoryBean extends AbstractFactoryBean<HealthReporter> {
+
+    private static final String CLASS_MICROMETER_METRICS = "io.micrometer.core.instrument.Metrics";
+
+    private final boolean isMicrometerPresent;
+
+    @SuppressWarnings("unused")
+    public AlfredTelemetryHealthReporterFactoryBean() {
+        this(ClassUtils.isPresent(CLASS_MICROMETER_METRICS, HealthReporter.class.getClassLoader()));
+    }
+
+    public AlfredTelemetryHealthReporterFactoryBean(boolean isMicrometerPresent) {
+        this.isMicrometerPresent = isMicrometerPresent;
+    }
+
+    @Setter
+    private boolean enabled;
+
+    @Override
+    public Class<?> getObjectType() {
+        return HealthReporter.class;
+    }
+
+    @Override
+    protected HealthReporter createInstance() {
+        if (isMicrometerPresent) {
+            AlfredTelemetryHealthReporter ret = new AlfredTelemetryHealthReporter();
+            ret.setEnabled(enabled);
+            return ret;
+        }
+
+        if (enabled) {
+            log.warn("{} enabled but Micrometer not found on the classpath. Is Alfred Telemetry installed?",
+                    AlfredTelemetryHealthReporter.class.getSimpleName());
+        }
+        return HealthReporter.DISABLED();
+    }
+}

--- a/alfresco-health-processor-platform/src/main/java/eu/xenit/alfresco/healthprocessor/reporter/telemetry/Constants.java
+++ b/alfresco-health-processor-platform/src/main/java/eu/xenit/alfresco/healthprocessor/reporter/telemetry/Constants.java
@@ -1,0 +1,27 @@
+package eu.xenit.alfresco.healthprocessor.reporter.telemetry;
+
+public interface Constants {
+
+    interface Key {
+
+        String BASE = "health-processor";
+
+        String ACTIVE = BASE + ".active";
+        String PLUGINS = BASE + ".plugins";
+        String REPORTS = BASE + ".reports";
+
+    }
+
+    interface Tag {
+
+        String PLUGIN = "plugin";
+        String STATUS = "status";
+
+    }
+
+    interface Description {
+
+        String PLUGINS = "Number of registered, active HealthProcessorPlugin implementations";
+    }
+
+}

--- a/alfresco-health-processor-platform/src/main/java/eu/xenit/alfresco/healthprocessor/reporter/telemetry/Constants.java
+++ b/alfresco-health-processor-platform/src/main/java/eu/xenit/alfresco/healthprocessor/reporter/telemetry/Constants.java
@@ -1,27 +1,34 @@
 package eu.xenit.alfresco.healthprocessor.reporter.telemetry;
 
-public interface Constants {
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 
-    interface Key {
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class Constants {
 
-        String BASE = "health-processor";
+    @NoArgsConstructor(access = AccessLevel.PRIVATE)
+    public static class Key {
 
-        String ACTIVE = BASE + ".active";
-        String PLUGINS = BASE + ".plugins";
-        String REPORTS = BASE + ".reports";
+        public static final String BASE = "health-processor";
 
-    }
-
-    interface Tag {
-
-        String PLUGIN = "plugin";
-        String STATUS = "status";
+        public static final String ACTIVE = BASE + ".active";
+        public static final String PLUGINS = BASE + ".plugins";
+        public static final String REPORTS = BASE + ".reports";
 
     }
 
-    interface Description {
+    @NoArgsConstructor(access = AccessLevel.PRIVATE)
+    public static class Tag {
 
-        String PLUGINS = "Number of registered, active HealthProcessorPlugin implementations";
+        public static final String PLUGIN = "plugin";
+        public static final String STATUS = "status";
+
+    }
+
+    @NoArgsConstructor(access = AccessLevel.PRIVATE)
+    public static class Description {
+
+        public static final String PLUGINS = "Number of registered, active HealthProcessorPlugin implementations";
     }
 
 }

--- a/alfresco-health-processor-platform/src/test/java/eu/xenit/alfresco/healthprocessor/indexing/IndexingConfigUtil.java
+++ b/alfresco-health-processor-platform/src/test/java/eu/xenit/alfresco/healthprocessor/indexing/IndexingConfigUtil.java
@@ -1,12 +1,11 @@
 package eu.xenit.alfresco.healthprocessor.indexing;
 
 import eu.xenit.alfresco.healthprocessor.indexing.IndexingConfiguration.IndexingStrategyKey;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class IndexingConfigUtil {
-
-    private IndexingConfigUtil() {
-        // private ctor to hide implicit public one
-    }
 
     public static IndexingConfiguration defaultConfig() {
         return config(-1L, Long.MAX_VALUE, 1000);

--- a/alfresco-health-processor-platform/src/test/java/eu/xenit/alfresco/healthprocessor/processing/ProcConfigUtil.java
+++ b/alfresco-health-processor-platform/src/test/java/eu/xenit/alfresco/healthprocessor/processing/ProcConfigUtil.java
@@ -1,10 +1,10 @@
 package eu.xenit.alfresco.healthprocessor.processing;
 
-public class ProcConfigUtil {
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 
-    private ProcConfigUtil() {
-        // private ctor to hide implicit public one
-    }
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class ProcConfigUtil {
 
     public static ProcessorConfiguration defaultConfig() {
         return config(true);

--- a/alfresco-health-processor-platform/src/test/java/eu/xenit/alfresco/healthprocessor/reporter/SummaryLoggingHealthReporterTest.java
+++ b/alfresco-health-processor-platform/src/test/java/eu/xenit/alfresco/healthprocessor/reporter/SummaryLoggingHealthReporterTest.java
@@ -12,10 +12,8 @@ import org.junit.jupiter.api.Test;
 
 class SummaryLoggingHealthReporterTest {
 
-    private static final NodeHealthReport REPORT_1 =
-            new NodeHealthReport(NodeHealthStatus.HEALTHY, TestNodeRefs.REFS[0]);
-    private static final NodeHealthReport REPORT_2 =
-            new NodeHealthReport(NodeHealthStatus.UNHEALTHY, TestNodeRefs.REFS[1]);
+    private static final NodeHealthReport REPORT_1 = TestReports.healthy();
+    private static final NodeHealthReport REPORT_2 = TestReports.unhealthy();
 
     @Test
     void smokeTest() {

--- a/alfresco-health-processor-platform/src/test/java/eu/xenit/alfresco/healthprocessor/reporter/TestReports.java
+++ b/alfresco-health-processor-platform/src/test/java/eu/xenit/alfresco/healthprocessor/reporter/TestReports.java
@@ -1,0 +1,27 @@
+package eu.xenit.alfresco.healthprocessor.reporter;
+
+import eu.xenit.alfresco.healthprocessor.reporter.api.NodeHealthReport;
+import eu.xenit.alfresco.healthprocessor.reporter.api.NodeHealthStatus;
+import eu.xenit.alfresco.healthprocessor.util.TestNodeRefs;
+
+public class TestReports {
+
+    private TestReports() {
+        // private ctor to hide implicit public one
+    }
+
+    private static int testRefsPointer = 0;
+
+    public static NodeHealthReport unhealthy() {
+        return random(NodeHealthStatus.UNHEALTHY);
+    }
+
+    public static NodeHealthReport healthy() {
+        return random(NodeHealthStatus.HEALTHY);
+    }
+
+    public static NodeHealthReport random(NodeHealthStatus status) {
+        return new NodeHealthReport(status, TestNodeRefs.REFS[testRefsPointer++]);
+    }
+
+}

--- a/alfresco-health-processor-platform/src/test/java/eu/xenit/alfresco/healthprocessor/reporter/TestReports.java
+++ b/alfresco-health-processor-platform/src/test/java/eu/xenit/alfresco/healthprocessor/reporter/TestReports.java
@@ -3,12 +3,11 @@ package eu.xenit.alfresco.healthprocessor.reporter;
 import eu.xenit.alfresco.healthprocessor.reporter.api.NodeHealthReport;
 import eu.xenit.alfresco.healthprocessor.reporter.api.NodeHealthStatus;
 import eu.xenit.alfresco.healthprocessor.util.TestNodeRefs;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class TestReports {
-
-    private TestReports() {
-        // private ctor to hide implicit public one
-    }
 
     private static int testRefsPointer = 0;
 

--- a/alfresco-health-processor-platform/src/test/java/eu/xenit/alfresco/healthprocessor/reporter/api/SingleReportHealthReporterTest.java
+++ b/alfresco-health-processor-platform/src/test/java/eu/xenit/alfresco/healthprocessor/reporter/api/SingleReportHealthReporterTest.java
@@ -7,7 +7,7 @@ import static org.hamcrest.Matchers.is;
 
 import eu.xenit.alfresco.healthprocessor.plugins.api.AssertHealthProcessorPlugin;
 import eu.xenit.alfresco.healthprocessor.plugins.api.HealthProcessorPlugin;
-import eu.xenit.alfresco.healthprocessor.util.TestNodeRefs;
+import eu.xenit.alfresco.healthprocessor.reporter.TestReports;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -15,10 +15,8 @@ import org.junit.jupiter.api.Test;
 
 class SingleReportHealthReporterTest {
 
-    private static final NodeHealthReport REPORT_1 =
-            new NodeHealthReport(NodeHealthStatus.HEALTHY, TestNodeRefs.REFS[0]);
-    private static final NodeHealthReport REPORT_2 =
-            new NodeHealthReport(NodeHealthStatus.UNHEALTHY, TestNodeRefs.REFS[1]);
+    private static final NodeHealthReport REPORT_1 = TestReports.healthy();
+    private static final NodeHealthReport REPORT_2 = TestReports.unhealthy();
 
     @Test
     void toggleable() {

--- a/alfresco-health-processor-platform/src/test/java/eu/xenit/alfresco/healthprocessor/reporter/telemetry/AlfredTelemetryHealthReporterFactoryBeanTest.java
+++ b/alfresco-health-processor-platform/src/test/java/eu/xenit/alfresco/healthprocessor/reporter/telemetry/AlfredTelemetryHealthReporterFactoryBeanTest.java
@@ -1,0 +1,55 @@
+package eu.xenit.alfresco.healthprocessor.reporter.telemetry;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+
+import eu.xenit.alfresco.healthprocessor.reporter.api.DisabledHealthReporter;
+import eu.xenit.alfresco.healthprocessor.reporter.api.HealthReporter;
+import org.junit.jupiter.api.Test;
+
+class AlfredTelemetryHealthReporterFactoryBeanTest {
+
+    @Test
+    void getObjectType() {
+        AlfredTelemetryHealthReporterFactoryBean factoryBean = new AlfredTelemetryHealthReporterFactoryBean();
+        assertThat(factoryBean.getObjectType(), is(equalTo(HealthReporter.class)));
+    }
+
+    @Test
+    void createInstance_micrometerPresent_enabled() {
+        assertCreateInstance(true, true, AlfredTelemetryHealthReporter.class, true);
+    }
+
+    @Test
+    void createInstance_micrometerNotPresent_enabled() {
+        assertCreateInstance(false, true, DisabledHealthReporter.class, false);
+    }
+
+    @Test
+    void createInstance_micrometerPresent_notEnabled() {
+        assertCreateInstance(true, false, AlfredTelemetryHealthReporter.class, false);
+    }
+
+    @Test
+    void createInstance_micrometerNotPresent_notEnabled() {
+        assertCreateInstance(false, false, DisabledHealthReporter.class, false);
+    }
+
+    private void assertCreateInstance(boolean isMicrometerPresent, boolean isEnabled,
+            Class<? extends HealthReporter> expectedClass, boolean expectedIsEnabled) {
+        AlfredTelemetryHealthReporterFactoryBean factoryBean = createFactoryBean(isMicrometerPresent, isEnabled);
+        HealthReporter createdBean = factoryBean.createInstance();
+        assertThat(createdBean, is(instanceOf(expectedClass)));
+        assertThat(createdBean.isEnabled(), is(equalTo(expectedIsEnabled)));
+    }
+
+    private AlfredTelemetryHealthReporterFactoryBean createFactoryBean(boolean isMicrometerPresent, boolean isEnabled) {
+        AlfredTelemetryHealthReporterFactoryBean ret =
+                new AlfredTelemetryHealthReporterFactoryBean(isMicrometerPresent);
+        ret.setEnabled(isEnabled);
+        return ret;
+    }
+
+}

--- a/alfresco-health-processor-platform/src/test/java/eu/xenit/alfresco/healthprocessor/reporter/telemetry/AlfredTelemetryHealthReporterTest.java
+++ b/alfresco-health-processor-platform/src/test/java/eu/xenit/alfresco/healthprocessor/reporter/telemetry/AlfredTelemetryHealthReporterTest.java
@@ -1,0 +1,88 @@
+package eu.xenit.alfresco.healthprocessor.reporter.telemetry;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+
+import eu.xenit.alfresco.healthprocessor.plugins.NoOpHealthProcessorPlugin;
+import eu.xenit.alfresco.healthprocessor.plugins.api.AssertHealthProcessorPlugin;
+import eu.xenit.alfresco.healthprocessor.reporter.TestReports;
+import eu.xenit.alfresco.healthprocessor.reporter.telemetry.Constants.Key;
+import eu.xenit.alfresco.healthprocessor.reporter.telemetry.Constants.Tag;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.search.RequiredSearch;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.util.StringUtils;
+
+class AlfredTelemetryHealthReporterTest {
+
+    private SimpleMeterRegistry meterRegistry;
+    AlfredTelemetryHealthReporter reporter;
+
+    @BeforeEach
+    void setup() {
+        meterRegistry = new SimpleMeterRegistry();
+        reporter = new AlfredTelemetryHealthReporter(meterRegistry);
+    }
+
+    @Test
+    void initializeWithStaticRegistry() {
+        AlfredTelemetryHealthReporter reporter = new AlfredTelemetryHealthReporter();
+        assertThat(reporter, is(notNullValue()));
+    }
+
+    @Test
+    void activeCounter() {
+        assertActiveGaugeEquals(0d);
+        reporter.onStart();
+        assertActiveGaugeEquals(1d);
+        reporter.onStop();
+        assertActiveGaugeEquals(0d);
+    }
+
+    @Test
+    void activePluginsCounter() {
+        reporter.processReport(TestReports.healthy(), AssertHealthProcessorPlugin.class);
+        assertThat(meterRegistry.get(Key.PLUGINS).gauge().value(), is(equalTo(1d)));
+    }
+
+    @Test
+    void reportsCounter() {
+        reporter.processReport(TestReports.healthy(), AssertHealthProcessorPlugin.class);
+        reporter.processReport(TestReports.healthy(), NoOpHealthProcessorPlugin.class);
+
+        assertThat(getReportCountersValue(null, null), is(equalTo(2d)));
+        assertThat(getReportCountersValue("HEALTHY", null), is(equalTo(2d)));
+        assertThat(getReportCountersValue("HEALTHY", "AssertHealthProcessorPlugin"), is(equalTo(1d)));
+        assertThat(getReportCountersValue(null, "NoOpHealthProcessorPlugin"), is(equalTo(1d)));
+
+        reporter.processReport(TestReports.unhealthy(), AssertHealthProcessorPlugin.class);
+        reporter.processReport(TestReports.unhealthy(), AssertHealthProcessorPlugin.class);
+
+        assertThat(getReportCountersValue(null, null), is(equalTo(4d)));
+        assertThat(getReportCountersValue("HEALTHY", null), is(equalTo(2d)));
+        assertThat(getReportCountersValue("UNHEALTHY", null), is(equalTo(2d)));
+        assertThat(getReportCountersValue("UNHEALTHY", "AssertHealthProcessorPlugin"), is(equalTo(2d)));
+        assertThat(getReportCountersValue(null, "NoOpHealthProcessorPlugin"), is(equalTo(1d)));
+    }
+
+    private void assertActiveGaugeEquals(double expected) {
+        assertThat(meterRegistry.get(Key.ACTIVE).gauge().value(), is(equalTo(expected)));
+    }
+
+    private double getReportCountersValue(String status, String pluginClazz) {
+        RequiredSearch search = meterRegistry.get(Key.REPORTS);
+        if (StringUtils.hasText(status)) {
+            search = search.tag(Tag.STATUS, status);
+        }
+        if (StringUtils.hasText(pluginClazz)) {
+            search = search.tag(Tag.PLUGIN, pluginClazz);
+        }
+
+        return search.counters().stream().mapToDouble(Counter::count).sum();
+    }
+
+}

--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,8 @@ sonarqube {
 
 ext {
     alfrescoVersion = '5.2.f'
+    alfredTelemetryVersion = '0.4.0'
+    micrometerVersion = '1.0.6'
     lombokVersion = '1.18.10'
     enterpriseEnabled = rootProject.hasProperty("enterprise")
 }

--- a/integration-tests/build.gradle
+++ b/integration-tests/build.gradle
@@ -71,6 +71,7 @@ subprojects { Project p ->
         baseAlfrescoWar "${alfrescoBaseWar}"
         alfrescoAmp project(path: ":integration-tests", configuration: "amp")
         alfrescoAmp project(path: ":alfresco-health-processor-platform", configuration: "amp")
+        alfrescoAmp "eu.xenit.alfred.telemetry:alfred-telemetry-platform:${alfredTelemetryVersion}@amp"
     }
 
     dockerAlfresco {

--- a/integration-tests/src/test/java/eu/xenit/alfresco/healthprocessor/integrationtest/AlfredTelemetryHealthReporterSmokeTest.java
+++ b/integration-tests/src/test/java/eu/xenit/alfresco/healthprocessor/integrationtest/AlfredTelemetryHealthReporterSmokeTest.java
@@ -1,0 +1,32 @@
+package eu.xenit.alfresco.healthprocessor.integrationtest;
+
+import static io.restassured.RestAssured.given;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public class AlfredTelemetryHealthReporterSmokeTest extends RestAssuredTest {
+
+    private static final String URI_BASE_METRICS = "s/alfred/telemetry/metrics/";
+
+    static Stream<String> namesOfMetersThatShouldBeAvailable() {
+        return Stream.of(
+                "health-processor.active",
+                "health-processor.plugins",
+                "health-processor.reports"
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("namesOfMetersThatShouldBeAvailable")
+    void assertMeterAvailable(String meterName) {
+        given()
+                .log().ifValidationFails()
+                .when()
+                .get(URI_BASE_METRICS + meterName)
+                .then()
+                .statusCode(200);
+    }
+
+}

--- a/integration-tests/src/test/java/eu/xenit/alfresco/healthprocessor/integrationtest/AlfredTelemetryHealthReporterSmokeTest.java
+++ b/integration-tests/src/test/java/eu/xenit/alfresco/healthprocessor/integrationtest/AlfredTelemetryHealthReporterSmokeTest.java
@@ -6,7 +6,7 @@ import java.util.stream.Stream;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
-public class AlfredTelemetryHealthReporterSmokeTest extends RestAssuredTest {
+class AlfredTelemetryHealthReporterSmokeTest extends RestAssuredTest {
 
     private static final String URI_BASE_METRICS = "s/alfred/telemetry/metrics/";
 

--- a/integration-tests/src/test/resources/compose/docker-compose.yml
+++ b/integration-tests/src/test/resources/compose/docker-compose.yml
@@ -17,6 +17,7 @@ services:
       - GLOBAL_eu.xenit.alfresco.healthprocessor.processing.max-batches-per-second=100
       - GLOBAL_eu.xenit.alfresco.healthprocessor.plugin.noop.enabled=true
       - GLOBAL_eu.xenit.alfresco.healthprocessor.reporter.log.summary.enabled=true
+      - GLOBAL_eu.xenit.alfresco.healthprocessor.reporter.alfred-telemetry.enabled=true
       - GLOBAL_eu.xenit.alfresco.healthprocessor.plugin.content-validation.enabled=true
       - GLOBAL_eu.xenit.alfresco.healthprocessor.plugin.content-validation.properties=cm:content
     depends_on:


### PR DESCRIPTION
Closes #17 

Exposed meters:

- `health-processor.active` gauge (0 or 1)
- `health-processor.plugins` gauge
- `health-processor.reports` counter. Tags: `status (UNHEALTHY, HEALTHY, NONE)` and `plugin` (simple name of plugin class)