### PR TITLE
Validate that plugins report on all nodes that they have been given.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ Version template:
 
 ## [0.4.1] - UNRELEASED
 
+### Added
+
+* [[#33](https://github.com/xenit-eu/alfresco-health-processor/pull/33)] Validate that plugins send reports for all nodes.
+
 
 ## [0.4.0] - 2021-07-08
 ### Added

--- a/alfresco-health-processor-platform/src/main/java/eu/xenit/alfresco/healthprocessor/indexing/IndexingStrategy.java
+++ b/alfresco-health-processor-platform/src/main/java/eu/xenit/alfresco/healthprocessor/indexing/IndexingStrategy.java
@@ -3,6 +3,7 @@ package eu.xenit.alfresco.healthprocessor.indexing;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+import javax.annotation.Nonnull;
 import org.alfresco.service.cmr.repository.NodeRef;
 
 /**
@@ -19,12 +20,14 @@ public interface IndexingStrategy {
 
     }
 
+    @Nonnull
     Set<NodeRef> getNextNodeIds(final int amount);
 
     default void onStop() {
 
     }
 
+    @Nonnull
     default Map<String, String> getState() {
         return new HashMap<>();
     }

--- a/alfresco-health-processor-platform/src/main/java/eu/xenit/alfresco/healthprocessor/indexing/IndexingStrategyFactoryBean.java
+++ b/alfresco-health-processor-platform/src/main/java/eu/xenit/alfresco/healthprocessor/indexing/IndexingStrategyFactoryBean.java
@@ -3,6 +3,7 @@ package eu.xenit.alfresco.healthprocessor.indexing;
 import eu.xenit.alfresco.healthprocessor.indexing.IndexingConfiguration.IndexingStrategyKey;
 import eu.xenit.alfresco.healthprocessor.indexing.txnid.TxnIdBasedIndexingStrategy;
 import eu.xenit.alfresco.healthprocessor.util.AttributeStore;
+import java.util.Objects;
 import lombok.AllArgsConstructor;
 import org.springframework.beans.factory.config.AbstractFactoryBean;
 
@@ -23,7 +24,12 @@ public final class IndexingStrategyFactoryBean extends AbstractFactoryBean<Index
         return createIndexingStrategy(configuration.getIndexingStrategy());
     }
 
-    private IndexingStrategy createIndexingStrategy(IndexingStrategyKey ignoreForNow) {
-        return new TxnIdBasedIndexingStrategy(configuration, trackingComponent, attributeStore);
+    private IndexingStrategy createIndexingStrategy(IndexingStrategyKey indexingStrategy) {
+        switch(indexingStrategy) {
+            case TXNID:
+                return new TxnIdBasedIndexingStrategy(configuration, trackingComponent, attributeStore);
+            default:
+                throw new IllegalArgumentException("Unknown indexing strategy: "+ Objects.toString(indexingStrategy));
+        }
     }
 }

--- a/alfresco-health-processor-platform/src/main/java/eu/xenit/alfresco/healthprocessor/indexing/txnid/TxnIdBasedIndexingStrategy.java
+++ b/alfresco-health-processor-platform/src/main/java/eu/xenit/alfresco/healthprocessor/indexing/txnid/TxnIdBasedIndexingStrategy.java
@@ -13,6 +13,7 @@ import java.util.Queue;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.LongStream;
+import javax.annotation.Nonnull;
 import lombok.RequiredArgsConstructor;
 import org.alfresco.service.cmr.repository.NodeRef;
 import org.slf4j.Logger;
@@ -34,6 +35,7 @@ public class TxnIdBasedIndexingStrategy implements IndexingStrategy {
     private final TrackingComponent trackingComponent;
     private final AttributeStore attributeStore;
 
+    @Nonnull
     @Override
     public Map<String, String> getState() {
         Map<String, String> ret = new HashMap<>();
@@ -60,6 +62,7 @@ public class TxnIdBasedIndexingStrategy implements IndexingStrategy {
     }
 
     @Override
+    @Nonnull
     public Set<NodeRef> getNextNodeIds(int amount) {
         Set<NodeRef> ret = new HashSet<>();
         while (!done && nodeQueue.size() < amount) {

--- a/alfresco-health-processor-platform/src/main/java/eu/xenit/alfresco/healthprocessor/plugins/ContentValidationHealthProcessorPlugin.java
+++ b/alfresco-health-processor-platform/src/main/java/eu/xenit/alfresco/healthprocessor/plugins/ContentValidationHealthProcessorPlugin.java
@@ -71,7 +71,7 @@ public class ContentValidationHealthProcessorPlugin extends SingleNodeHealthProc
     @Override
     protected NodeHealthReport process(NodeRef nodeRef) {
         if (!nodeService.exists(nodeRef) || nodeService.getNodeStatus(nodeRef).isDeleted()) {
-            return null;
+            return new NodeHealthReport(NodeHealthStatus.NONE, nodeRef, "Node does not exist or is deleted");
         }
 
         Map<QName, Serializable> properties = nodeService.getProperties(nodeRef);

--- a/alfresco-health-processor-platform/src/main/java/eu/xenit/alfresco/healthprocessor/plugins/api/HealthProcessorPlugin.java
+++ b/alfresco-health-processor-platform/src/main/java/eu/xenit/alfresco/healthprocessor/plugins/api/HealthProcessorPlugin.java
@@ -2,6 +2,7 @@ package eu.xenit.alfresco.healthprocessor.plugins.api;
 
 import eu.xenit.alfresco.healthprocessor.reporter.api.NodeHealthReport;
 import java.util.Set;
+import javax.annotation.Nonnull;
 import org.alfresco.service.cmr.repository.NodeRef;
 
 /**
@@ -24,6 +25,7 @@ public interface HealthProcessorPlugin {
      * @return is is not mandatory to return anything. All returned {@link NodeHealthReport reports} will be offered to
      * {@link eu.xenit.alfresco.healthprocessor.reporter.api.HealthReporter} instances.
      */
+    @Nonnull
     Set<NodeHealthReport> process(Set<NodeRef> nodeRefs);
 
 }

--- a/alfresco-health-processor-platform/src/main/java/eu/xenit/alfresco/healthprocessor/plugins/api/ToggleableHealthProcessorPlugin.java
+++ b/alfresco-health-processor-platform/src/main/java/eu/xenit/alfresco/healthprocessor/plugins/api/ToggleableHealthProcessorPlugin.java
@@ -2,6 +2,7 @@ package eu.xenit.alfresco.healthprocessor.plugins.api;
 
 import eu.xenit.alfresco.healthprocessor.reporter.api.NodeHealthReport;
 import java.util.Set;
+import javax.annotation.Nonnull;
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
 import org.alfresco.service.cmr.repository.NodeRef;
@@ -17,6 +18,7 @@ public abstract class ToggleableHealthProcessorPlugin implements HealthProcessor
         return log;
     }
 
+    @Nonnull
     @Override
     public final Set<NodeHealthReport> process(Set<NodeRef> nodeRefs) {
         getLogger().debug("Processing batch of #{} nodeRefs", nodeRefs.size());
@@ -24,5 +26,6 @@ public abstract class ToggleableHealthProcessorPlugin implements HealthProcessor
         return doProcess(nodeRefs);
     }
 
+    @Nonnull
     protected abstract Set<NodeHealthReport> doProcess(Set<NodeRef> nodeRefs);
 }

--- a/alfresco-health-processor-platform/src/main/java/eu/xenit/alfresco/healthprocessor/processing/ProcessorService.java
+++ b/alfresco-health-processor-platform/src/main/java/eu/xenit/alfresco/healthprocessor/processing/ProcessorService.java
@@ -7,7 +7,7 @@ import eu.xenit.alfresco.healthprocessor.reporter.ReportsService;
 import eu.xenit.alfresco.healthprocessor.reporter.api.NodeHealthReport;
 import eu.xenit.alfresco.healthprocessor.reporter.api.NodeHealthStatus;
 import eu.xenit.alfresco.healthprocessor.util.TransactionHelper;
-import java.util.HashMap;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -92,8 +92,8 @@ public class ProcessorService {
     private void processNodeBatch(Set<NodeRef> nodesToProcess) {
         ParameterCheck.mandatory("nodesToProcess", nodesToProcess);
 
+        Set<NodeRef> copy = Collections.unmodifiableSet(nodesToProcess);
         for (HealthProcessorPlugin plugin : plugins) {
-            Set<NodeRef> copy = new HashSet<>(nodesToProcess);
             this.processNodeBatchRateLimited(copy, plugin);
         }
     }
@@ -116,33 +116,38 @@ public class ProcessorService {
         log.debug("Plugin '{}' will process #{} nodes", plugin.getClass().getCanonicalName(),
                 nodesToProcess.size());
 
-        Set<NodeHealthReport> reports = transactionHelper
-                .inNewTransaction(() -> plugin.process(nodesToProcess), configuration.isReadOnly());
+        Set<NodeHealthReport> pluginReports = transactionHelper
+                .inNewTransaction(() -> Collections.unmodifiableSet(plugin.process(nodesToProcess)), configuration.isReadOnly());
 
-        validateNodeReports(nodesToProcess, reports, plugin);
+        Set<NodeHealthReport> reports = validateNodeReports(nodesToProcess, pluginReports, plugin);
 
         transactionHelper.inNewTransaction(() -> reportsService.processReports(plugin.getClass(), reports), false);
     }
 
-    private void validateNodeReports(Set<NodeRef> nodesToProcess, Set<NodeHealthReport> reports, HealthProcessorPlugin plugin) {
-        if(reports.size() != nodesToProcess.size()) {
-            log.warn("Plugin '{}' returned #{} reports for #{} nodes", plugin.getClass().getCanonicalName(), reports.size(), nodesToProcess.size());
-            Set<NodeRef> reportedNodes = reports.stream().map(NodeHealthReport::getNodeRef).collect(Collectors.toSet());
+    private Set<NodeHealthReport> validateNodeReports(Set<NodeRef> nodesToProcess, Set<NodeHealthReport> reports, HealthProcessorPlugin plugin) {
+        Set<NodeHealthReport> nodeHealthReports = reports;
+        if(nodeHealthReports.size() != nodesToProcess.size()) {
+            log.warn("Plugin '{}' returned #{} reports for #{} nodes", plugin.getClass().getCanonicalName(), nodeHealthReports.size(), nodesToProcess.size());
+            Set<NodeRef> reportedNodes = nodeHealthReports.stream().map(NodeHealthReport::getNodeRef).collect(Collectors.toSet());
 
             // Locate unreported nodes
             Set<NodeRef> unreportedNodes = new HashSet<>(nodesToProcess);
             unreportedNodes.removeAll(reportedNodes);
             log.warn("Plugin '{}' did not report for #{} nodes", plugin.getClass().getCanonicalName(), unreportedNodes.size());
             log.trace("Plugin '{}' did not report nodes: {}", plugin.getClass().getCanonicalName(), unreportedNodes);
-            reports.addAll(
-                    unreportedNodes.stream()
-                            .map(nodeRef -> new NodeHealthReport(NodeHealthStatus.UNREPORTED, nodeRef))
-                            .collect(Collectors.toSet())
-            );
+            if(!unreportedNodes.isEmpty()) {
+                nodeHealthReports = new HashSet<>(nodeHealthReports); // We have to create a copy here, because reports is an unmodifiable Set
+                nodeHealthReports.addAll(
+                        unreportedNodes.stream()
+                                .map(nodeRef -> new NodeHealthReport(NodeHealthStatus.UNREPORTED, nodeRef))
+                                .collect(Collectors.toSet())
+                );
+                nodeHealthReports = Collections.unmodifiableSet(nodeHealthReports);
+            }
 
             // Locate double reported nodes
-            if(reportedNodes.size() != reports.size()) {
-                Map<NodeRef, Set<NodeHealthReport>> reportedNodeCount = reports.stream()
+            if(reportedNodes.size() != nodeHealthReports.size()) {
+                Map<NodeRef, Set<NodeHealthReport>> reportedNodeCount = nodeHealthReports.stream()
                         .collect(Collectors.groupingBy(NodeHealthReport::getNodeRef, Collectors.toSet()));
 
                 Map<NodeRef, Set<NodeHealthReport>> duplicateHealthReports = reportedNodeCount.entrySet().stream()
@@ -164,6 +169,7 @@ public class ProcessorService {
                 log.trace("Plugin '{}' reported for unrequested nodes: {}", plugin.getClass().getCanonicalName(), reportedNodesWithoutRequested);
             }
         }
+        return nodeHealthReports;
     }
 
     private boolean hasNoEnabledPlugins() {

--- a/alfresco-health-processor-platform/src/main/java/eu/xenit/alfresco/healthprocessor/reporter/SummaryLoggingHealthReporter.java
+++ b/alfresco-health-processor-platform/src/main/java/eu/xenit/alfresco/healthprocessor/reporter/SummaryLoggingHealthReporter.java
@@ -4,6 +4,7 @@ import eu.xenit.alfresco.healthprocessor.reporter.api.NodeHealthReport;
 import eu.xenit.alfresco.healthprocessor.reporter.api.ProcessorPluginOverview;
 import eu.xenit.alfresco.healthprocessor.reporter.api.ToggleableHealthReporter;
 import java.util.List;
+import javax.annotation.Nonnull;
 import lombok.EqualsAndHashCode;
 import lombok.extern.slf4j.Slf4j;
 import org.alfresco.util.ParameterCheck;
@@ -21,7 +22,7 @@ public class SummaryLoggingHealthReporter extends ToggleableHealthReporter {
     }
 
     @Override
-    public void onCycleDone(List<ProcessorPluginOverview> overviews) {
+    public void onCycleDone(@Nonnull List<ProcessorPluginOverview> overviews) {
         ParameterCheck.mandatory("overviews", overviews);
         
         log.info("Health-Processor done in {}", printDuration());
@@ -30,7 +31,7 @@ public class SummaryLoggingHealthReporter extends ToggleableHealthReporter {
     }
 
     @Override
-    public void onException(Exception e) {
+    public void onException(@Nonnull Exception e) {
         log.warn("Health-Processor failed. Duration: {}, exception: {}", printDuration(), e.getMessage());
     }
 

--- a/alfresco-health-processor-platform/src/main/java/eu/xenit/alfresco/healthprocessor/reporter/api/DisabledHealthReporter.java
+++ b/alfresco-health-processor-platform/src/main/java/eu/xenit/alfresco/healthprocessor/reporter/api/DisabledHealthReporter.java
@@ -2,6 +2,7 @@ package eu.xenit.alfresco.healthprocessor.reporter.api;
 
 import eu.xenit.alfresco.healthprocessor.plugins.api.HealthProcessorPlugin;
 import java.util.Set;
+import javax.annotation.Nonnull;
 
 public final class DisabledHealthReporter implements HealthReporter {
 
@@ -11,7 +12,7 @@ public final class DisabledHealthReporter implements HealthReporter {
     }
 
     @Override
-    public void processReports(Class<? extends HealthProcessorPlugin> pluginClass, Set<NodeHealthReport> reports) {
+    public void processReports(@Nonnull Class<? extends HealthProcessorPlugin> pluginClass, @Nonnull Set<NodeHealthReport> reports) {
         throw new UnsupportedOperationException("The DisabledHealthReporter shouldn't process reports");
     }
 }

--- a/alfresco-health-processor-platform/src/main/java/eu/xenit/alfresco/healthprocessor/reporter/api/HealthReporter.java
+++ b/alfresco-health-processor-platform/src/main/java/eu/xenit/alfresco/healthprocessor/reporter/api/HealthReporter.java
@@ -3,6 +3,7 @@ package eu.xenit.alfresco.healthprocessor.reporter.api;
 import eu.xenit.alfresco.healthprocessor.plugins.api.HealthProcessorPlugin;
 import java.util.List;
 import java.util.Set;
+import javax.annotation.Nonnull;
 
 public interface HealthReporter {
 
@@ -12,15 +13,15 @@ public interface HealthReporter {
 
     }
 
-    default void processReports(Class<? extends HealthProcessorPlugin> pluginClass, Set<NodeHealthReport> reports) {
+    default void processReports(@Nonnull Class<? extends HealthProcessorPlugin> pluginClass, @Nonnull Set<NodeHealthReport> reports) {
 
     }
 
-    default void onCycleDone(List<ProcessorPluginOverview> overviews) {
+    default void onCycleDone(@Nonnull List<ProcessorPluginOverview> overviews) {
 
     }
 
-    default void onException(Exception e) {
+    default void onException(@Nonnull Exception e) {
 
     }
 

--- a/alfresco-health-processor-platform/src/main/java/eu/xenit/alfresco/healthprocessor/reporter/api/NodeHealthReport.java
+++ b/alfresco-health-processor-platform/src/main/java/eu/xenit/alfresco/healthprocessor/reporter/api/NodeHealthReport.java
@@ -5,23 +5,25 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
+import javax.annotation.Nonnull;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Value;
 import org.alfresco.service.cmr.repository.NodeRef;
 
 @Value
-@AllArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class NodeHealthReport implements Serializable {
 
-    public NodeHealthReport(NodeHealthStatus status, NodeRef nodeRef) {
+    public NodeHealthReport(@Nonnull NodeHealthStatus status, @Nonnull NodeRef nodeRef) {
         this(status, nodeRef, Collections.emptySet());
     }
 
-    public NodeHealthReport(NodeHealthStatus status, NodeRef nodeRef, String... messages) {
+    public NodeHealthReport(@Nonnull NodeHealthStatus status, @Nonnull NodeRef nodeRef, String... messages) {
         this(status, nodeRef, Arrays.asList(messages));
     }
 
-    public NodeHealthReport(NodeHealthStatus status, NodeRef nodeRef, Collection<String> messages) {
+    public NodeHealthReport(@Nonnull NodeHealthStatus status, @Nonnull NodeRef nodeRef, Collection<String> messages) {
         this(status, nodeRef, new HashSet<>(messages));
     }
 

--- a/alfresco-health-processor-platform/src/main/java/eu/xenit/alfresco/healthprocessor/reporter/api/NodeHealthStatus.java
+++ b/alfresco-health-processor-platform/src/main/java/eu/xenit/alfresco/healthprocessor/reporter/api/NodeHealthStatus.java
@@ -3,5 +3,6 @@ package eu.xenit.alfresco.healthprocessor.reporter.api;
 public enum NodeHealthStatus {
     HEALTHY,
     UNHEALTHY,
-    NONE
+    NONE,
+    UNREPORTED
 }

--- a/alfresco-health-processor-platform/src/main/java/eu/xenit/alfresco/healthprocessor/reporter/api/SingleReportHealthReporter.java
+++ b/alfresco-health-processor-platform/src/main/java/eu/xenit/alfresco/healthprocessor/reporter/api/SingleReportHealthReporter.java
@@ -4,6 +4,7 @@ import eu.xenit.alfresco.healthprocessor.plugins.api.HealthProcessorPlugin;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
+import javax.annotation.Nonnull;
 
 public abstract class SingleReportHealthReporter extends ToggleableHealthReporter {
 
@@ -15,7 +16,7 @@ public abstract class SingleReportHealthReporter extends ToggleableHealthReporte
     }
 
     @Override
-    public void processReports(Class<? extends HealthProcessorPlugin> pluginClass, Set<NodeHealthReport> reports) {
+    public void processReports(@Nonnull Class<? extends HealthProcessorPlugin> pluginClass, @Nonnull Set<NodeHealthReport> reports) {
         Set<NodeHealthStatus> statusesToHandle = statusesToHandle();
 
         for (NodeHealthReport report : reports) {
@@ -26,5 +27,5 @@ public abstract class SingleReportHealthReporter extends ToggleableHealthReporte
 
     }
 
-    protected abstract void processReport(NodeHealthReport report, Class<? extends HealthProcessorPlugin> pluginClass);
+    protected abstract void processReport(@Nonnull NodeHealthReport report, Class<? extends HealthProcessorPlugin> pluginClass);
 }

--- a/alfresco-health-processor-platform/src/main/java/eu/xenit/alfresco/healthprocessor/reporter/telemetry/AlfredTelemetryHealthReporter.java
+++ b/alfresco-health-processor-platform/src/main/java/eu/xenit/alfresco/healthprocessor/reporter/telemetry/AlfredTelemetryHealthReporter.java
@@ -18,6 +18,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
+import javax.annotation.Nonnull;
 import lombok.EqualsAndHashCode;
 import lombok.Value;
 
@@ -52,12 +53,12 @@ public class AlfredTelemetryHealthReporter extends SingleReportHealthReporter {
     }
 
     @Override
-    public void onCycleDone(List<ProcessorPluginOverview> overviews) {
+    public void onCycleDone(@Nonnull List<ProcessorPluginOverview> overviews) {
         isActive.set(false);
     }
 
     @Override
-    public void onException(Exception e) {
+    public void onException(@Nonnull Exception e) {
         isActive.set(false);
     }
 

--- a/alfresco-health-processor-platform/src/main/java/eu/xenit/alfresco/healthprocessor/reporter/telemetry/Constants.java
+++ b/alfresco-health-processor-platform/src/main/java/eu/xenit/alfresco/healthprocessor/reporter/telemetry/Constants.java
@@ -7,7 +7,7 @@ import lombok.NoArgsConstructor;
 public final class Constants {
 
     @NoArgsConstructor(access = AccessLevel.PRIVATE)
-    public static class Key {
+    public static final class Key {
 
         public static final String BASE = "health-processor";
 
@@ -18,7 +18,7 @@ public final class Constants {
     }
 
     @NoArgsConstructor(access = AccessLevel.PRIVATE)
-    public static class Tag {
+    public static final class Tag {
 
         public static final String PLUGIN = "plugin";
         public static final String STATUS = "status";
@@ -26,7 +26,7 @@ public final class Constants {
     }
 
     @NoArgsConstructor(access = AccessLevel.PRIVATE)
-    public static class Description {
+    public static final class Description {
 
         public static final String PLUGINS = "Number of registered, active HealthProcessorPlugin implementations";
     }

--- a/alfresco-health-processor-platform/src/test/java/eu/xenit/alfresco/healthprocessor/plugins/ContentValidationHealthProcessorPluginTest.java
+++ b/alfresco-health-processor-platform/src/test/java/eu/xenit/alfresco/healthprocessor/plugins/ContentValidationHealthProcessorPluginTest.java
@@ -97,11 +97,18 @@ class ContentValidationHealthProcessorPluginTest {
         ContentValidationHealthProcessorPlugin plugin = initialize(Collections.singletonList(Q_NAME));
 
         when(nodeService.exists(NODE_REF)).thenReturn(false);
-        assertThat(plugin.process(NODE_REF), is(nullValue()));
+        NodeHealthReport report = plugin.process(NODE_REF);
+        assertThat(report, is(notNullValue()));
+        assertThat(report.getStatus(), is(equalTo(NodeHealthStatus.NONE)));
+        assertThat(report.getNodeRef(), is(equalTo(NODE_REF)));
 
         when(nodeService.exists(NODE_REF)).thenReturn(true);
         when(nodeService.getNodeStatus(NODE_REF)).thenReturn(new Status(100L, NODE_REF, null, 10L, true));
-        assertThat(plugin.process(NODE_REF), is(nullValue()));
+
+        report = plugin.process(NODE_REF);
+        assertThat(report, is(notNullValue()));
+        assertThat(report.getStatus(), is(equalTo(NodeHealthStatus.NONE)));
+        assertThat(report.getNodeRef(), is(equalTo(NODE_REF)));
     }
 
     @Test

--- a/alfresco-health-processor-platform/src/test/java/eu/xenit/alfresco/healthprocessor/plugins/api/AssertHealthProcessorPlugin.java
+++ b/alfresco-health-processor-platform/src/test/java/eu/xenit/alfresco/healthprocessor/plugins/api/AssertHealthProcessorPlugin.java
@@ -8,6 +8,7 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 
 import eu.xenit.alfresco.healthprocessor.reporter.api.NodeHealthReport;
+import java.util.Collections;
 import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -33,7 +34,7 @@ public class AssertHealthProcessorPlugin extends ToggleableHealthProcessorPlugin
     @Override
     protected Set<NodeHealthReport> doProcess(Set<NodeRef> nodeRefs) {
         invocations.offer(nodeRefs);
-        return null;
+        return Collections.emptySet();
     }
 
     public int getNumberOfInvocations() {

--- a/alfresco-health-processor-platform/src/test/java/eu/xenit/alfresco/healthprocessor/reporter/api/SingleReportHealthReporterTest.java
+++ b/alfresco-health-processor-platform/src/test/java/eu/xenit/alfresco/healthprocessor/reporter/api/SingleReportHealthReporterTest.java
@@ -11,6 +11,7 @@ import eu.xenit.alfresco.healthprocessor.reporter.TestReports;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
+import javax.annotation.Nonnull;
 import org.junit.jupiter.api.Test;
 
 class SingleReportHealthReporterTest {
@@ -64,7 +65,7 @@ class SingleReportHealthReporterTest {
         }
 
         @Override
-        public void onCycleDone(List<ProcessorPluginOverview> overviews) {
+        public void onCycleDone(@Nonnull List<ProcessorPluginOverview> overviews) {
 
         }
 

--- a/integration-tests/src/main/java/eu/xenit/alfresco/healthprocessor/example/ExampleHealthProcessorPlugin.java
+++ b/integration-tests/src/main/java/eu/xenit/alfresco/healthprocessor/example/ExampleHealthProcessorPlugin.java
@@ -35,7 +35,7 @@ public class ExampleHealthProcessorPlugin extends SingleNodeHealthProcessorPlugi
     protected NodeHealthReport process(NodeRef nodeRef) {
         if (!StoreRef.STORE_REF_WORKSPACE_SPACESSTORE.equals(nodeRef.getStoreRef())) {
             logger.debug("Ignoring '{}', since we are only interested in workspace://SpacesStore nodes", nodeRef);
-            return null;
+            return new NodeHealthReport(NodeHealthStatus.NONE, nodeRef, "Node is not in workspace://SpacesStore");
         }
         numberOfNodesProcessed++;
 


### PR DESCRIPTION
Due to bugs or mistakes in health processor plugins, it is possible that they accidentally do not report some nodes, or send multiple health reports for the same node.

To alert on and prevent such mistakes (primarily during development of the plugin), a best-effort check is performed to validate that the outgoing reports match following requirements:

- For every NodeRef sent in to the health processor plugin, there is exactly one NodeHealthReport.
- There is no NodeHealthReport for NodeRefs that were not sent to the health processor plugin.