### PR TITLE
Add user-friendly progress indicator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Version template:
 * [[#33](https://github.com/xenit-eu/alfresco-health-processor/pull/33)] Validate that plugins send reports for all nodes.
 * [[#34](https://github.com/xenit-eu/alfresco-health-processor/pull/34)] Solr index validation plugin
 * [[#35](https://github.com/xenit-eu/alfresco-health-processor/pull/35)] Last N transactions indexing strategy
+* [[#36](https://github.com/xenit-eu/alfresco-health-processor/pull/36)] User-friendly progress reporting
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -224,6 +224,9 @@ Exposed metrics:
 * `health-processor.active`  
   Available tags: /  
   A gauge with value 0 or 1, indicating if the reporter and hence by extension the Health-Processor is active
+* `health-processor.progress`
+  Available tags: /
+  A gauge with a value between 0.0 and 1.0, indicating the progress of the current Health-Processor cycle
 * `health-processor.plugins`  
   Available tags: /  
   A gauge indicating the number of active `HealthProcessorPlugin` implementations.
@@ -251,6 +254,18 @@ Example output:
  2021-03-03 12:40:40,274  WARN  [healthprocessor.reporter.SummaryLoggingHealthReporter] [DefaultScheduler_Worker-2] Plugin[ContentValidationHealthProcessorPlugin] (#1): 
  2021-03-03 12:40:40,275  WARN  [healthprocessor.reporter.SummaryLoggingHealthReporter] [DefaultScheduler_Worker-2] 	workspace://SpacesStore/86796712-4dc6-4b8d-973f-a943ef7f23ed: [Property: '{http://www.alfresco.org/model/content/1.0}content', contentUrl: 'store://2021/3/3/12/27/cb664208-abae-4da9-b7ee-81167a43041a.bin']
  2021-03-03 12:40:40,275  WARN  [healthprocessor.reporter.SummaryLoggingHealthReporter] [DefaultScheduler_Worker-2]  --- 
+```
+
+Activation property: `eu.xenit.alfresco.healthprocessor.reporter.log.progress.enabled=true`
+
+A simple implementation that writes progress of a Health Processor cycle to the Alfresco logs.
+
+Relevant logger: `log4j.logger.eu.xenit.alfresco.healthprocessor.reporter.ProgressLoggingHealthReporter=INFO`
+
+Example output:
+```text
+2021-08-27 08:25:44,150  INFO  [healthprocessor.reporter.ProgressLoggingHealthReporter] [DefaultScheduler_Worker-6] Health-Processor iteration 47% completed. ETA: 00:00:27.000
+2021-08-27 08:25:44,196  INFO  [healthprocessor.reporter.ProgressLoggingHealthReporter] [DefaultScheduler_Worker-6] Health-Processor iteration 53% completed. ETA: 00:00:21.000
 ```
 
 ## Extension points

--- a/alfresco-health-processor-platform/src/main/amp/config/alfresco/subsystems/HealthProcessor/default/healthprocessor.properties
+++ b/alfresco-health-processor-platform/src/main/amp/config/alfresco/subsystems/HealthProcessor/default/healthprocessor.properties
@@ -32,3 +32,4 @@ eu.xenit.alfresco.healthprocessor.plugin.solr-index.endpoints.archive.indexed-st
 
 eu.xenit.alfresco.healthprocessor.reporter.alfred-telemetry.enabled=false
 eu.xenit.alfresco.healthprocessor.reporter.log.summary.enabled=false
+eu.xenit.alfresco.healthprocessor.reporter.log.progress.enabled=false

--- a/alfresco-health-processor-platform/src/main/amp/config/alfresco/subsystems/HealthProcessor/default/reporter-context.xml
+++ b/alfresco-health-processor-platform/src/main/amp/config/alfresco/subsystems/HealthProcessor/default/reporter-context.xml
@@ -20,6 +20,11 @@
         <property name="enabled" value="${eu.xenit.alfresco.healthprocessor.reporter.log.summary.enabled}"/>
     </bean>
 
+    <bean id="eu.xenit.alfresco.healthprocessor.reporter.ProgressLoggingHealthReporter"
+            class="eu.xenit.alfresco.healthprocessor.reporter.ProgressLoggingHealthReporter">
+        <property name="enabled" value="${eu.xenit.alfresco.healthprocessor.reporter.log.progress.enabled}"/>
+    </bean>
+
     <bean id="eu.xenit.alfresco.healthprocessor.reporter.telemetry.AlfredTelemetryHealthReporter"
             class="eu.xenit.alfresco.healthprocessor.reporter.telemetry.AlfredTelemetryHealthReporterFactoryBean">
         <property name="enabled" value="${eu.xenit.alfresco.healthprocessor.reporter.alfred-telemetry.enabled}"/>

--- a/alfresco-health-processor-platform/src/main/amp/config/alfresco/templates/webscripts/org/alfresco/enterprise/repository/admin/support-tools/health-processor-admin-console.get.html.ftl
+++ b/alfresco-health-processor-platform/src/main/amp/config/alfresco/templates/webscripts/org/alfresco/enterprise/repository/admin/support-tools/health-processor-admin-console.get.html.ftl
@@ -16,6 +16,22 @@
         <@field label="ID"
             description="The ID of the Indexing Strategy in use"
             value="${healthprocessor.indexing.id}" />
+        <#assign progress=healthprocessor.indexing.progress>
+        <@field label="Progress"
+            description="Completion percentage for this iteration"
+            value="${progress.progress}" />
+        <@field label="Elapsed time"
+            description="Started at ${progress.startTime?datetime}"
+            value="${progress.elapsed}" />
+        <#if progress.estimatedCompletionTime??>
+            <@field label="Estimated completion"
+                description="Estimated to finish at ${progress.estimatedCompletionTime?datetime}"
+                value="${progress.estimatedCompletion}" />
+        <#else>
+            <@field label="Estimated completion"
+                description="Estimated completion time can not be calculated"
+                value="Unknown" />
+        </#if>
         <div class="column-left">
             <h4>State</h4>
             <ul>

--- a/alfresco-health-processor-platform/src/main/amp/config/alfresco/templates/webscripts/org/alfresco/enterprise/repository/admin/support-tools/health-processor-admin-console.get.html.ftl
+++ b/alfresco-health-processor-platform/src/main/amp/config/alfresco/templates/webscripts/org/alfresco/enterprise/repository/admin/support-tools/health-processor-admin-console.get.html.ftl
@@ -12,26 +12,40 @@
     </div>
 
     <div class="column-full">
+        <@section label="Cycle progress"/>
+        <#assign progress=healthprocessor.indexing.progress>
+        <#if !progress.isNone()>
+            <@field label="Progress"
+                description="Completion percentage for this iteration"
+                value="${progress.progress}" />
+            <@field label="Elapsed time"
+                description="Started at ${progress.startTime?datetime}"
+                value="${progress.elapsed}" />
+            <#if progress.estimatedCompletionTime??>
+                <@field label="Estimated completion"
+                    description="Estimated to finish at ${progress.estimatedCompletionTime?datetime}"
+                    value="${progress.estimatedCompletion}" />
+            <#else>
+                <@field label="Estimated completion"
+                    description="Estimated completion time can not be calculated"
+                    value="Unknown" />
+            </#if>
+        <#else>
+            <p>No progress information is currently available,
+            <#if healthprocessor.status != "ACTIVE">
+                because there is no health-processor cycle active.
+            <#else>
+                because the current indexing strategy does not report progress information.
+            </#if>
+            </p>
+        </#if>
+    </div>
+
+    <div class="column-full">
         <@section label="Indexing Strategy"/>
         <@field label="ID"
             description="The ID of the Indexing Strategy in use"
             value="${healthprocessor.indexing.id}" />
-        <#assign progress=healthprocessor.indexing.progress>
-        <@field label="Progress"
-            description="Completion percentage for this iteration"
-            value="${progress.progress}" />
-        <@field label="Elapsed time"
-            description="Started at ${progress.startTime?datetime}"
-            value="${progress.elapsed}" />
-        <#if progress.estimatedCompletionTime??>
-            <@field label="Estimated completion"
-                description="Estimated to finish at ${progress.estimatedCompletionTime?datetime}"
-                value="${progress.estimatedCompletion}" />
-        <#else>
-            <@field label="Estimated completion"
-                description="Estimated completion time can not be calculated"
-                value="Unknown" />
-        </#if>
         <div class="column-left">
             <h4>State</h4>
             <ul>

--- a/alfresco-health-processor-platform/src/main/java/eu/xenit/alfresco/healthprocessor/indexing/IndexingProgress.java
+++ b/alfresco-health-processor-platform/src/main/java/eu/xenit/alfresco/healthprocessor/indexing/IndexingProgress.java
@@ -1,0 +1,24 @@
+package eu.xenit.alfresco.healthprocessor.indexing;
+
+import java.time.Duration;
+import java.util.Optional;
+import javax.annotation.Nonnull;
+
+public interface IndexingProgress {
+
+    IndexingProgress NONE = NullIndexingProgress.INSTANCE;
+
+    float getProgress();
+
+    Duration getElapsed();
+
+    @Nonnull
+    default Optional<Duration> getEstimatedCompletion() {
+        long done = (long) (getProgress() * 10_000L);
+        long toDo = 10_000L - done;
+        if (done == 0) {
+            return Optional.empty();
+        }
+        return Optional.of(getElapsed().dividedBy(done).multipliedBy(toDo));
+    }
+}

--- a/alfresco-health-processor-platform/src/main/java/eu/xenit/alfresco/healthprocessor/indexing/IndexingStrategy.java
+++ b/alfresco-health-processor-platform/src/main/java/eu/xenit/alfresco/healthprocessor/indexing/IndexingStrategy.java
@@ -34,6 +34,11 @@ public interface IndexingStrategy {
         return new HashMap<>();
     }
 
+    @Nonnull
+    default IndexingProgress getIndexingProgress() {
+        return IndexingProgress.NONE;
+    }
+
     enum IndexingStrategyKey {
         TXNID("txn-id"),
         LAST_TXNS("last-txns");

--- a/alfresco-health-processor-platform/src/main/java/eu/xenit/alfresco/healthprocessor/indexing/NullIndexingProgress.java
+++ b/alfresco-health-processor-platform/src/main/java/eu/xenit/alfresco/healthprocessor/indexing/NullIndexingProgress.java
@@ -1,0 +1,31 @@
+package eu.xenit.alfresco.healthprocessor.indexing;
+
+import java.time.Duration;
+import java.util.Optional;
+import javax.annotation.Nonnull;
+
+
+final class NullIndexingProgress implements IndexingProgress {
+
+    static final NullIndexingProgress INSTANCE = new NullIndexingProgress();
+
+    private NullIndexingProgress() {
+
+    }
+
+    @Override
+    public float getProgress() {
+        return Float.NaN;
+    }
+
+    @Override
+    public Duration getElapsed() {
+        return Duration.ZERO;
+    }
+
+    @Nonnull
+    @Override
+    public Optional<Duration> getEstimatedCompletion() {
+        return Optional.empty();
+    }
+}

--- a/alfresco-health-processor-platform/src/main/java/eu/xenit/alfresco/healthprocessor/indexing/SimpleIndexingProgress.java
+++ b/alfresco-health-processor-platform/src/main/java/eu/xenit/alfresco/healthprocessor/indexing/SimpleIndexingProgress.java
@@ -9,9 +9,13 @@ import lombok.RequiredArgsConstructor;
 public class SimpleIndexingProgress implements IndexingProgress {
 
     private final long startId;
-    private final Instant startTime = Instant.now();
+    private final Instant startTime;
     private final long endId;
     private final LongSupplier currentId;
+
+    public SimpleIndexingProgress(long startId, long endId, LongSupplier currentId) {
+        this(startId, Instant.now(), endId, currentId);
+    }
 
     private static float interpolate(float start, float end, float current) {
         return clampPercentage((current - start) / (end - start));
@@ -23,7 +27,7 @@ public class SimpleIndexingProgress implements IndexingProgress {
 
     @Override
     public float getProgress() {
-        return interpolate(startId, endId, currentId.getAsLong());
+        return interpolate(startId - 1, endId, currentId.getAsLong());
     }
 
     @Override

--- a/alfresco-health-processor-platform/src/main/java/eu/xenit/alfresco/healthprocessor/indexing/SimpleIndexingProgress.java
+++ b/alfresco-health-processor-platform/src/main/java/eu/xenit/alfresco/healthprocessor/indexing/SimpleIndexingProgress.java
@@ -1,0 +1,33 @@
+package eu.xenit.alfresco.healthprocessor.indexing;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.function.LongSupplier;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class SimpleIndexingProgress implements IndexingProgress {
+
+    private final long startId;
+    private final Instant startTime = Instant.now();
+    private final long endId;
+    private final LongSupplier currentId;
+
+    private static float interpolate(float start, float end, float current) {
+        return clampPercentage((current - start) / (end - start));
+    }
+
+    private static float clampPercentage(float in) {
+        return Math.max(0, Math.min(1, in));
+    }
+
+    @Override
+    public float getProgress() {
+        return interpolate(startId, endId, currentId.getAsLong());
+    }
+
+    @Override
+    public Duration getElapsed() {
+        return Duration.between(startTime, Instant.now());
+    }
+}

--- a/alfresco-health-processor-platform/src/main/java/eu/xenit/alfresco/healthprocessor/indexing/SimpleIndexingProgress.java
+++ b/alfresco-health-processor-platform/src/main/java/eu/xenit/alfresco/healthprocessor/indexing/SimpleIndexingProgress.java
@@ -17,8 +17,9 @@ public class SimpleIndexingProgress implements IndexingProgress {
         this(startId, Instant.now(), endId, currentId);
     }
 
-    private static float interpolate(float start, float end, float current) {
-        return clampPercentage((current - start) / (end - start));
+    private static float interpolate(long start, long end, long current) {
+        // We are casting one side of the division to a float, so it performs float division instead of integer division
+        return clampPercentage((float)(current - start) / (end - start));
     }
 
     private static float clampPercentage(float in) {

--- a/alfresco-health-processor-platform/src/main/java/eu/xenit/alfresco/healthprocessor/indexing/lasttxns/LastTxnsIndexingConfiguration.java
+++ b/alfresco-health-processor-platform/src/main/java/eu/xenit/alfresco/healthprocessor/indexing/lasttxns/LastTxnsIndexingConfiguration.java
@@ -22,7 +22,7 @@ public class LastTxnsIndexingConfiguration implements IndexingConfiguration {
     @Override
     public Map<String, String> getConfiguration() {
         Map<String, String> ret = new HashMap<>();
-        ret.put("number-of-transactions", Long.toString(lookbackTransactions));
+        ret.put("lookback-transactions", Long.toString(lookbackTransactions));
         ret.put("txn-batch-size", Long.toString(batchSize));
         return ret;
     }

--- a/alfresco-health-processor-platform/src/main/java/eu/xenit/alfresco/healthprocessor/indexing/txnid/TxnIdBasedIndexingStrategy.java
+++ b/alfresco-health-processor-platform/src/main/java/eu/xenit/alfresco/healthprocessor/indexing/txnid/TxnIdBasedIndexingStrategy.java
@@ -62,7 +62,7 @@ public class TxnIdBasedIndexingStrategy implements IndexingStrategy {
         nodeQueue.clear();
         initializeStartTxnId();
         initializeMaxTxnId();
-        indexingProgress = new SimpleIndexingProgress(nextStartTxnIdToFetch, maxTxnIdInclusive, () -> nextStartTxnIdToFetch);
+        indexingProgress = new SimpleIndexingProgress(nextStartTxnIdToFetch, maxTxnIdInclusive, () -> nextStartTxnIdToFetch - 1);
     }
 
     @Override

--- a/alfresco-health-processor-platform/src/main/java/eu/xenit/alfresco/healthprocessor/indexing/txnid/TxnIdBasedIndexingStrategy.java
+++ b/alfresco-health-processor-platform/src/main/java/eu/xenit/alfresco/healthprocessor/indexing/txnid/TxnIdBasedIndexingStrategy.java
@@ -1,6 +1,8 @@
 package eu.xenit.alfresco.healthprocessor.indexing.txnid;
 
+import eu.xenit.alfresco.healthprocessor.indexing.IndexingProgress;
 import eu.xenit.alfresco.healthprocessor.indexing.IndexingStrategy;
+import eu.xenit.alfresco.healthprocessor.indexing.SimpleIndexingProgress;
 import eu.xenit.alfresco.healthprocessor.indexing.TrackingComponent;
 import eu.xenit.alfresco.healthprocessor.indexing.TrackingComponent.NodeInfo;
 import eu.xenit.alfresco.healthprocessor.util.AttributeStore;
@@ -33,6 +35,7 @@ public class TxnIdBasedIndexingStrategy implements IndexingStrategy {
     private final TxnIdIndexingConfiguration configuration;
     private final TrackingComponent trackingComponent;
     private final AttributeStore attributeStore;
+    private IndexingProgress indexingProgress = IndexingProgress.NONE;
 
     @Nonnull
     @Override
@@ -47,17 +50,25 @@ public class TxnIdBasedIndexingStrategy implements IndexingStrategy {
         return ret;
     }
 
+    @Nonnull
+    @Override
+    public IndexingProgress getIndexingProgress() {
+        return indexingProgress;
+    }
+
     @Override
     public void onStart() {
         done = false;
         nodeQueue.clear();
         initializeStartTxnId();
         initializeMaxTxnId();
+        indexingProgress = new SimpleIndexingProgress(nextStartTxnIdToFetch, maxTxnIdInclusive, () -> nextStartTxnIdToFetch);
     }
 
     @Override
     public void onStop() {
         attributeStore.removeAttributes(ATTR_KEY_LAST_PROCESSED_TXN_ID);
+        indexingProgress = IndexingProgress.NONE;
     }
 
     @Override

--- a/alfresco-health-processor-platform/src/main/java/eu/xenit/alfresco/healthprocessor/plugins/api/ToggleableHealthProcessorPlugin.java
+++ b/alfresco-health-processor-platform/src/main/java/eu/xenit/alfresco/healthprocessor/plugins/api/ToggleableHealthProcessorPlugin.java
@@ -3,15 +3,17 @@ package eu.xenit.alfresco.healthprocessor.plugins.api;
 import eu.xenit.alfresco.healthprocessor.reporter.api.NodeHealthReport;
 import java.util.Set;
 import javax.annotation.Nonnull;
-import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.alfresco.service.cmr.repository.NodeRef;
 import org.slf4j.Logger;
 
 @Slf4j
-@Data
 public abstract class ToggleableHealthProcessorPlugin implements HealthProcessorPlugin {
 
+    @Getter
+    @Setter
     private boolean enabled;
 
     protected Logger getLogger() {

--- a/alfresco-health-processor-platform/src/main/java/eu/xenit/alfresco/healthprocessor/processing/ProcessorService.java
+++ b/alfresco-health-processor-platform/src/main/java/eu/xenit/alfresco/healthprocessor/processing/ProcessorService.java
@@ -79,9 +79,11 @@ public class ProcessorService {
     private void executeInternal() {
         Set<NodeRef> nodesToProcess = getNextNodesInTransaction();
         while (!nodesToProcess.isEmpty()) {
+            updateIndexingProgress();
             this.processNodeBatch(nodesToProcess);
             nodesToProcess = getNextNodesInTransaction();
         }
+        updateIndexingProgress();
     }
 
     private Set<NodeRef> getNextNodesInTransaction() {
@@ -122,6 +124,10 @@ public class ProcessorService {
         Set<NodeHealthReport> reports = validateNodeReports(nodesToProcess, pluginReports, plugin);
 
         transactionHelper.inNewTransaction(() -> reportsService.processReports(plugin.getClass(), reports), false);
+    }
+
+    private void updateIndexingProgress() {
+        transactionHelper.inNewTransaction(() -> reportsService.onProgress(indexingStrategy.getClass(), indexingStrategy.getIndexingProgress()), false);
     }
 
     private Set<NodeHealthReport> validateNodeReports(Set<NodeRef> nodesToProcess, Set<NodeHealthReport> reports, HealthProcessorPlugin plugin) {

--- a/alfresco-health-processor-platform/src/main/java/eu/xenit/alfresco/healthprocessor/reporter/ProgressLoggingHealthReporter.java
+++ b/alfresco-health-processor-platform/src/main/java/eu/xenit/alfresco/healthprocessor/reporter/ProgressLoggingHealthReporter.java
@@ -1,0 +1,45 @@
+package eu.xenit.alfresco.healthprocessor.reporter;
+
+import eu.xenit.alfresco.healthprocessor.indexing.IndexingProgress;
+import eu.xenit.alfresco.healthprocessor.indexing.IndexingStrategy;
+import eu.xenit.alfresco.healthprocessor.reporter.api.ToggleableHealthReporter;
+import java.time.Duration;
+import javax.annotation.Nonnull;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.time.DurationFormatUtils;
+
+@Slf4j
+public class ProgressLoggingHealthReporter extends ToggleableHealthReporter {
+
+    private float lastProgressPercentage;
+
+    @Override
+    public void onStart() {
+        lastProgressPercentage = 0;
+    }
+
+    @Override
+    public void onProgress(@Nonnull Class<? extends IndexingStrategy> indexingStrategyClass,
+            @Nonnull IndexingProgress progress) {
+        if (!log.isInfoEnabled()) {
+            return;
+        }
+
+        float progressPercentage = progress.getProgress();
+        if (Float.isNaN(progressPercentage)) {
+            return;
+        }
+
+        // Progress is less than 1%, don't log
+        if (progressPercentage - lastProgressPercentage < 0.01) {
+            return;
+        }
+
+        log.info("Health-Processor iteration {}% completed. ETA: {}",
+                Math.round(progressPercentage * 100),
+                progress.getEstimatedCompletion().map(duration -> duration.withNanos(0)).map(Duration::toMillis)
+                        .map(DurationFormatUtils::formatDurationHMS).orElse("Unknown")
+        );
+        lastProgressPercentage = progressPercentage;
+    }
+}

--- a/alfresco-health-processor-platform/src/main/java/eu/xenit/alfresco/healthprocessor/reporter/ReportsService.java
+++ b/alfresco-health-processor-platform/src/main/java/eu/xenit/alfresco/healthprocessor/reporter/ReportsService.java
@@ -1,5 +1,7 @@
 package eu.xenit.alfresco.healthprocessor.reporter;
 
+import eu.xenit.alfresco.healthprocessor.indexing.IndexingProgress;
+import eu.xenit.alfresco.healthprocessor.indexing.IndexingStrategy;
 import eu.xenit.alfresco.healthprocessor.plugins.api.HealthProcessorPlugin;
 import eu.xenit.alfresco.healthprocessor.reporter.api.HealthReporter;
 import eu.xenit.alfresco.healthprocessor.reporter.api.NodeHealthReport;
@@ -31,6 +33,10 @@ public class ReportsService {
 
     public void onException(Exception e) {
         forEachEnabledReporter(reporter -> reporter.onException(e));
+    }
+
+    public void onProgress(Class<? extends IndexingStrategy> indexingStrategyClass, IndexingProgress progress) {
+        forEachEnabledReporter(reporter -> reporter.onProgress(indexingStrategyClass, progress));
     }
 
     public void onCycleDone() {

--- a/alfresco-health-processor-platform/src/main/java/eu/xenit/alfresco/healthprocessor/reporter/SummaryLoggingHealthReporter.java
+++ b/alfresco-health-processor-platform/src/main/java/eu/xenit/alfresco/healthprocessor/reporter/SummaryLoggingHealthReporter.java
@@ -1,11 +1,8 @@
 package eu.xenit.alfresco.healthprocessor.reporter;
 
-import eu.xenit.alfresco.healthprocessor.indexing.IndexingProgress;
-import eu.xenit.alfresco.healthprocessor.indexing.IndexingStrategy;
 import eu.xenit.alfresco.healthprocessor.reporter.api.NodeHealthReport;
 import eu.xenit.alfresco.healthprocessor.reporter.api.ProcessorPluginOverview;
 import eu.xenit.alfresco.healthprocessor.reporter.api.ToggleableHealthReporter;
-import java.time.Duration;
 import java.util.List;
 import javax.annotation.Nonnull;
 import lombok.EqualsAndHashCode;
@@ -18,12 +15,10 @@ import org.apache.commons.lang3.time.DurationFormatUtils;
 public class SummaryLoggingHealthReporter extends ToggleableHealthReporter {
 
     long startMs;
-    float lastProgressPercentage;
 
     @Override
     public void onStart() {
         startMs = System.currentTimeMillis();
-        lastProgressPercentage = 0;
     }
 
     @Override
@@ -33,23 +28,6 @@ public class SummaryLoggingHealthReporter extends ToggleableHealthReporter {
         log.info("Health-Processor done in {}", printDuration());
         logSummary(overviews);
         logUnhealthyNodes(overviews);
-    }
-
-    @Override
-    public void onProgress(@Nonnull Class<? extends IndexingStrategy> indexingStrategyClass,
-            @Nonnull IndexingProgress progress) {
-        if(log.isInfoEnabled()) {
-
-            float progressPercentage = progress.getProgress();
-            // If more progress than 1%
-            if(progressPercentage - lastProgressPercentage > 0.01) {
-                log.info("Health-Processor iteration {}% completed. ETA: {}",
-                        Math.round(progressPercentage*100),
-                        progress.getEstimatedCompletion().map(duration -> duration.withNanos(0)).map(Duration::toMillis).map(DurationFormatUtils::formatDurationHMS).orElse("Unknown")
-                );
-                lastProgressPercentage = progressPercentage;
-            }
-        }
     }
 
     @Override

--- a/alfresco-health-processor-platform/src/main/java/eu/xenit/alfresco/healthprocessor/reporter/api/HealthReporter.java
+++ b/alfresco-health-processor-platform/src/main/java/eu/xenit/alfresco/healthprocessor/reporter/api/HealthReporter.java
@@ -1,5 +1,7 @@
 package eu.xenit.alfresco.healthprocessor.reporter.api;
 
+import eu.xenit.alfresco.healthprocessor.indexing.IndexingProgress;
+import eu.xenit.alfresco.healthprocessor.indexing.IndexingStrategy;
 import eu.xenit.alfresco.healthprocessor.plugins.api.HealthProcessorPlugin;
 import java.util.List;
 import java.util.Set;
@@ -18,6 +20,11 @@ public interface HealthReporter {
     }
 
     default void onCycleDone(@Nonnull List<ProcessorPluginOverview> overviews) {
+
+    }
+
+    default void onProgress(@Nonnull Class<? extends IndexingStrategy> indexingStrategyClass, @Nonnull
+            IndexingProgress progress) {
 
     }
 

--- a/alfresco-health-processor-platform/src/main/java/eu/xenit/alfresco/healthprocessor/reporter/api/ToggleableHealthReporter.java
+++ b/alfresco-health-processor-platform/src/main/java/eu/xenit/alfresco/healthprocessor/reporter/api/ToggleableHealthReporter.java
@@ -1,10 +1,12 @@
 package eu.xenit.alfresco.healthprocessor.reporter.api;
 
-import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
 
-@Data
 public abstract class ToggleableHealthReporter implements HealthReporter {
 
+    @Getter
+    @Setter
     private boolean enabled;
 
 }

--- a/alfresco-health-processor-platform/src/main/java/eu/xenit/alfresco/healthprocessor/reporter/telemetry/Constants.java
+++ b/alfresco-health-processor-platform/src/main/java/eu/xenit/alfresco/healthprocessor/reporter/telemetry/Constants.java
@@ -12,6 +12,7 @@ public final class Constants {
         public static final String BASE = "health-processor";
 
         public static final String ACTIVE = BASE + ".active";
+        public static final String PROGRESS = BASE + ".progress";
         public static final String PLUGINS = BASE + ".plugins";
         public static final String REPORTS = BASE + ".reports";
 
@@ -29,6 +30,7 @@ public final class Constants {
     public static final class Description {
 
         public static final String PLUGINS = "Number of registered, active HealthProcessorPlugin implementations";
+        public static final String PROGRESS = "Completion percentage of the current cycle (0.0-1.0)";
     }
 
 }

--- a/alfresco-health-processor-platform/src/main/java/eu/xenit/alfresco/healthprocessor/webscripts/console/model/IndexingProgressView.java
+++ b/alfresco-health-processor-platform/src/main/java/eu/xenit/alfresco/healthprocessor/webscripts/console/model/IndexingProgressView.java
@@ -29,14 +29,13 @@ public class IndexingProgressView {
     }
 
     public String getElapsed() {
-        return DurationFormatUtils.formatDurationHMS(indexingProgress.getElapsed().withNanos(0).toMillis());
+        return format(indexingProgress.getElapsed().withNanos(0));
     }
 
     public String getEstimatedCompletion() {
         return indexingProgress.getEstimatedCompletion()
                 .map(duration -> duration.withNanos(0))
-                .map(Duration::toMillis)
-                .map(DurationFormatUtils::formatDurationHMS)
+                .map(IndexingProgressView::format)
                 .orElse("Unknown");
     }
 
@@ -45,5 +44,24 @@ public class IndexingProgressView {
                 .map(duration -> Instant.now().plus(duration))
                 .map(Date::from)
                 .orElse(null);
+    }
+
+    private static String format(Duration duration) {
+        long fullDays = duration.toDays();
+        Duration rest = duration.minusDays(fullDays);
+        StringBuilder formattedDuration = new StringBuilder();
+        if(fullDays > 0) {
+            formattedDuration.append(fullDays)
+                    .append(' ')
+                    .append("day");
+            if(fullDays > 1) {
+                formattedDuration.append('s');
+            }
+            formattedDuration.append(' ');
+        }
+
+        formattedDuration.append(DurationFormatUtils.formatDuration(rest.toMillis(), "HH:mm:ss"));
+
+        return formattedDuration.toString();
     }
 }

--- a/alfresco-health-processor-platform/src/main/java/eu/xenit/alfresco/healthprocessor/webscripts/console/model/IndexingProgressView.java
+++ b/alfresco-health-processor-platform/src/main/java/eu/xenit/alfresco/healthprocessor/webscripts/console/model/IndexingProgressView.java
@@ -12,6 +12,10 @@ public class IndexingProgressView {
 
     private final IndexingProgress indexingProgress;
 
+    public boolean isNone() {
+        return indexingProgress == IndexingProgress.NONE;
+    }
+
     public String getProgress() {
         float progress = indexingProgress.getProgress();
         if (Float.isNaN(progress)) {

--- a/alfresco-health-processor-platform/src/main/java/eu/xenit/alfresco/healthprocessor/webscripts/console/model/IndexingProgressView.java
+++ b/alfresco-health-processor-platform/src/main/java/eu/xenit/alfresco/healthprocessor/webscripts/console/model/IndexingProgressView.java
@@ -1,0 +1,45 @@
+package eu.xenit.alfresco.healthprocessor.webscripts.console.model;
+
+import eu.xenit.alfresco.healthprocessor.indexing.IndexingProgress;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Date;
+import lombok.AllArgsConstructor;
+import org.apache.commons.lang3.time.DurationFormatUtils;
+
+@AllArgsConstructor
+public class IndexingProgressView {
+
+    private final IndexingProgress indexingProgress;
+
+    public String getProgress() {
+        float progress = indexingProgress.getProgress();
+        if (Float.isNaN(progress)) {
+            return "Unknown";
+        }
+        return String.format("%.2f%%", progress * 100);
+    }
+
+    public Date getStartTime() {
+        return Date.from(Instant.now().minus(indexingProgress.getElapsed()));
+    }
+
+    public String getElapsed() {
+        return DurationFormatUtils.formatDurationHMS(indexingProgress.getElapsed().withNanos(0).toMillis());
+    }
+
+    public String getEstimatedCompletion() {
+        return indexingProgress.getEstimatedCompletion()
+                .map(duration -> duration.withNanos(0))
+                .map(Duration::toMillis)
+                .map(DurationFormatUtils::formatDurationHMS)
+                .orElse("Unknown");
+    }
+
+    public Date getEstimatedCompletionTime() {
+        return indexingProgress.getEstimatedCompletion()
+                .map(duration -> Instant.now().plus(duration))
+                .map(Date::from)
+                .orElse(null);
+    }
+}

--- a/alfresco-health-processor-platform/src/main/java/eu/xenit/alfresco/healthprocessor/webscripts/console/model/IndexingStrategyView.java
+++ b/alfresco-health-processor-platform/src/main/java/eu/xenit/alfresco/healthprocessor/webscripts/console/model/IndexingStrategyView.java
@@ -2,6 +2,7 @@ package eu.xenit.alfresco.healthprocessor.webscripts.console.model;
 
 import eu.xenit.alfresco.healthprocessor.indexing.IndexingConfiguration;
 import eu.xenit.alfresco.healthprocessor.indexing.IndexingStrategy.IndexingStrategyKey;
+import eu.xenit.alfresco.healthprocessor.indexing.IndexingProgress;
 import eu.xenit.alfresco.healthprocessor.indexing.IndexingStrategy;
 import java.util.HashMap;
 import java.util.Map;
@@ -17,11 +18,14 @@ public class IndexingStrategyView {
     Map<String, String> state;
     Map<String, String> configuration;
 
+    IndexingProgressView progress;
+
     public IndexingStrategyView(IndexingConfiguration configuration, IndexingStrategy strategy) {
         this(
                 configuration.getIndexingStrategy().getKey(),
                 strategy.getState(),
-                configuration.getConfiguration()
+                configuration.getConfiguration(),
+                new IndexingProgressView(strategy.getIndexingProgress())
         );
     }
 }

--- a/alfresco-health-processor-platform/src/test/java/eu/xenit/alfresco/healthprocessor/indexing/SimpleIndexingProgressTest.java
+++ b/alfresco-health-processor-platform/src/test/java/eu/xenit/alfresco/healthprocessor/indexing/SimpleIndexingProgressTest.java
@@ -1,0 +1,66 @@
+package eu.xenit.alfresco.healthprocessor.indexing;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.closeTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+class SimpleIndexingProgressTest {
+
+    @Test
+    void progress_none() {
+        Instant startTime = Instant.now().minus(1, ChronoUnit.DAYS);
+        IndexingProgress progress = new SimpleIndexingProgress(1, startTime, 10, () -> 0);
+
+        assertEquals(0, progress.getProgress());
+        assertThat(progress.getElapsed().withNanos(0), is(Duration.ofDays(1)));
+        assertEquals(Optional.empty(), progress.getEstimatedCompletion());
+    }
+
+    @Test
+    void progress_partial() {
+        Instant startTime = Instant.now().minus(9, ChronoUnit.DAYS);
+        IndexingProgress progress = new SimpleIndexingProgress(1, startTime, 10, () -> 9);
+
+        assertThat((double) progress.getProgress(), is(closeTo(0.9, 0.01)));
+        assertThat(progress.getElapsed().withNanos(0), is(Duration.ofDays(9)));
+        assertThat(progress.getEstimatedCompletion().map(d -> d.withNanos(0)), is(Optional.of(Duration.ofDays(1))));
+    }
+
+    @Test
+    void progress_partial_small() {
+        Instant startTime = Instant.now().minus(9, ChronoUnit.DAYS);
+        IndexingProgress progress = new SimpleIndexingProgress(1, startTime, 2, () -> 1);
+
+        assertThat((double) progress.getProgress(), is(closeTo(0.5, 0.01)));
+        assertThat(progress.getElapsed().withNanos(0), is(Duration.ofDays(9)));
+        assertThat(progress.getEstimatedCompletion().map(d -> d.withNanos(0)), is(Optional.of(Duration.ofDays(9))));
+    }
+
+    @Test
+    void progress_partial_large() {
+        Instant startTime = Instant.now().minus(9, ChronoUnit.DAYS);
+        IndexingProgress progress = new SimpleIndexingProgress(1, startTime, Long.MAX_VALUE, () -> Long.MAX_VALUE / 2);
+
+        assertThat((double) progress.getProgress(), is(closeTo(0.5, 0.01)));
+        assertThat(progress.getElapsed().withNanos(0), is(Duration.ofDays(9)));
+        assertThat(progress.getEstimatedCompletion().map(d -> d.withNanos(0)), is(Optional.of(Duration.ofDays(9))));
+    }
+
+    @Test
+    void progress_complete() {
+        Instant startTime = Instant.now().minus(9, ChronoUnit.DAYS);
+        IndexingProgress progress = new SimpleIndexingProgress(1, startTime, 10, () -> 10);
+
+        assertThat(progress.getProgress(), is(1.0F));
+        assertThat(progress.getElapsed().withNanos(0), is(Duration.ofDays(9)));
+        assertThat(progress.getEstimatedCompletion(), is(Optional.of(Duration.ZERO)));
+    }
+
+}

--- a/alfresco-health-processor-platform/src/test/java/eu/xenit/alfresco/healthprocessor/reporter/ProgressLoggingHealthReporterTest.java
+++ b/alfresco-health-processor-platform/src/test/java/eu/xenit/alfresco/healthprocessor/reporter/ProgressLoggingHealthReporterTest.java
@@ -1,0 +1,17 @@
+package eu.xenit.alfresco.healthprocessor.reporter;
+
+import eu.xenit.alfresco.healthprocessor.indexing.AssertIndexingStrategy;
+import eu.xenit.alfresco.healthprocessor.indexing.IndexingProgress;
+import org.junit.jupiter.api.Test;
+
+class ProgressLoggingHealthReporterTest {
+
+    @Test
+    void smokeTest() {
+        ProgressLoggingHealthReporter reporter = new ProgressLoggingHealthReporter();
+
+        reporter.onStart();
+        reporter.onProgress(AssertIndexingStrategy.class, IndexingProgress.NONE);
+    }
+
+}

--- a/alfresco-health-processor-platform/src/test/java/eu/xenit/alfresco/healthprocessor/reporter/ReportsServiceTest.java
+++ b/alfresco-health-processor-platform/src/test/java/eu/xenit/alfresco/healthprocessor/reporter/ReportsServiceTest.java
@@ -3,13 +3,17 @@ package eu.xenit.alfresco.healthprocessor.reporter;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
+import eu.xenit.alfresco.healthprocessor.indexing.AssertIndexingStrategy;
+import eu.xenit.alfresco.healthprocessor.indexing.SimpleIndexingProgress;
 import eu.xenit.alfresco.healthprocessor.plugins.AssertHealthProcessorPlugin;
 import eu.xenit.alfresco.healthprocessor.plugins.api.HealthProcessorPlugin;
 import eu.xenit.alfresco.healthprocessor.reporter.api.HealthReporter;
@@ -85,6 +89,13 @@ class ReportsServiceTest {
         service.onException(new VerySpecificException("JIKES"));
 
         verify(healthReporter).onException(any(VerySpecificException.class));
+    }
+
+    @Test
+    void onProgress() {
+        service.onProgress(AssertIndexingStrategy.class, new SimpleIndexingProgress(0, 1, () -> 1));
+
+        verify(healthReporter).onProgress(eq(AssertIndexingStrategy.class), any(SimpleIndexingProgress.class));
     }
 
     @Test

--- a/alfresco-health-processor-platform/src/test/java/eu/xenit/alfresco/healthprocessor/reporter/SummaryLoggingHealthReporterTest.java
+++ b/alfresco-health-processor-platform/src/test/java/eu/xenit/alfresco/healthprocessor/reporter/SummaryLoggingHealthReporterTest.java
@@ -4,6 +4,8 @@ import static eu.xenit.alfresco.healthprocessor.util.SetUtil.set;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
+import eu.xenit.alfresco.healthprocessor.indexing.AssertIndexingStrategy;
+import eu.xenit.alfresco.healthprocessor.indexing.IndexingProgress;
 import eu.xenit.alfresco.healthprocessor.plugins.AssertHealthProcessorPlugin;
 import eu.xenit.alfresco.healthprocessor.reporter.api.NodeHealthReport;
 import eu.xenit.alfresco.healthprocessor.reporter.api.NodeHealthStatus;
@@ -34,6 +36,7 @@ class SummaryLoggingHealthReporterTest {
 
         reporter.onStart();
         reporter.processReports(AssertHealthProcessorPlugin.class, set(REPORT_1, REPORT_2));
+        reporter.onProgress(AssertIndexingStrategy.class, IndexingProgress.NONE);
         reporter.onCycleDone(Collections.singletonList(overview));
     }
 

--- a/alfresco-health-processor-platform/src/test/java/eu/xenit/alfresco/healthprocessor/webscripts/console/ResponseViewRendererTest.java
+++ b/alfresco-health-processor-platform/src/test/java/eu/xenit/alfresco/healthprocessor/webscripts/console/ResponseViewRendererTest.java
@@ -64,6 +64,10 @@ class ResponseViewRendererTest {
         assertThat(view.getIndexing().getId(), is("txn-id"));
         assertThat(view.getIndexing().getConfiguration().keySet(), is(not(empty())));
 
+        assertThat(view.getIndexing().getProgress(), is(notNullValue()));
+        assertThat(view.getIndexing().getProgress().isNone(), is(equalTo(true)));
+        assertThat(view.getIndexing().getProgress().getProgress(), is(equalTo("Unknown")));
+
         assertThat(view.getPlugins(), is(notNullValue()));
         assertThat(view.getPlugins().getPlugins(), hasSize(1));
         assertThat(view.getPlugins().getPlugins().get(0).getName(), is(equalTo("AssertHealthProcessorPlugin")));
@@ -72,6 +76,6 @@ class ResponseViewRendererTest {
         assertThat(view.getReporters().getReporters(), hasSize(1));
         assertThat(view.getReporters().getReporters().get(0).getName(), is(equalTo("SummaryLoggingHealthReporter")));
 
-    }
 
+    }
 }

--- a/alfresco-health-processor-platform/src/test/java/eu/xenit/alfresco/healthprocessor/webscripts/console/model/IndexingProgressViewTest.java
+++ b/alfresco-health-processor-platform/src/test/java/eu/xenit/alfresco/healthprocessor/webscripts/console/model/IndexingProgressViewTest.java
@@ -1,0 +1,268 @@
+package eu.xenit.alfresco.healthprocessor.webscripts.console.model;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+
+import eu.xenit.alfresco.healthprocessor.indexing.IndexingProgress;
+import eu.xenit.alfresco.healthprocessor.indexing.SimpleIndexingProgress;
+import java.sql.Date;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Optional;
+import javax.annotation.Nonnull;
+import org.junit.jupiter.api.Test;
+
+class IndexingProgressViewTest {
+
+    @Test
+    void isNone_none() {
+        IndexingProgressView indexingProgressView = new IndexingProgressView(IndexingProgress.NONE);
+
+        assertThat(indexingProgressView.isNone(), is(equalTo(true)));
+    }
+
+    @Test
+    void isNone_other() {
+        IndexingProgressView indexingProgressView = new IndexingProgressView(new SimpleIndexingProgress(0, 0, () -> 0));
+
+        assertThat(indexingProgressView.isNone(), is(equalTo(false)));
+    }
+
+    @Test
+    void getProgress_unknown() {
+        IndexingProgress mockIndexingProgress = new IndexingProgress() {
+            @Override
+            public float getProgress() {
+                return Float.NaN;
+            }
+
+            @Override
+            public Duration getElapsed() {
+                return Duration.ZERO;
+            }
+        };
+
+        IndexingProgressView indexingProgressView = new IndexingProgressView(mockIndexingProgress);
+
+        assertThat(indexingProgressView.getProgress(), is(equalTo("Unknown")));
+    }
+
+    @Test
+    void getProgress_percentage() {
+        IndexingProgress mockIndexingProgress = new IndexingProgress() {
+            @Override
+            public float getProgress() {
+                return 0.1f;
+            }
+
+            @Override
+            public Duration getElapsed() {
+                return Duration.ZERO;
+            }
+        };
+
+        IndexingProgressView indexingProgressView = new IndexingProgressView(mockIndexingProgress);
+
+        assertThat(indexingProgressView.getProgress(), is(equalTo("10.00%")));
+    }
+
+    @Test
+    void getStartTime() {
+        Instant now = Instant.now().minus(1, ChronoUnit.HOURS);
+        IndexingProgress mockIndexingProgress = new IndexingProgress() {
+            @Override
+            public float getProgress() {
+                return 0.1f;
+            }
+
+            @Override
+            public Duration getElapsed() {
+                return Duration.between(now, Instant.now());
+            }
+        };
+
+        IndexingProgressView indexingProgressView = new IndexingProgressView(mockIndexingProgress);
+
+        assertThat(indexingProgressView.getStartTime(), is(equalTo(Date.from(now))));
+    }
+
+    @Test
+    void getElapsed_short() {
+        IndexingProgress mockIndexingProgress = new IndexingProgress() {
+            @Override
+            public float getProgress() {
+                return 0.1f;
+            }
+
+            @Override
+            public Duration getElapsed() {
+                return Duration.of(2, ChronoUnit.HOURS)
+                        .plus(5, ChronoUnit.MINUTES)
+                        .plus(24, ChronoUnit.SECONDS);
+            }
+        };
+        IndexingProgressView indexingProgressView = new IndexingProgressView(mockIndexingProgress);
+
+        assertThat(indexingProgressView.getElapsed(), is(equalTo("02:05:24")));
+    }
+
+    @Test
+    void getElapsed_day() {
+        IndexingProgress mockIndexingProgress = new IndexingProgress() {
+            @Override
+            public float getProgress() {
+                return 0.1f;
+            }
+
+            @Override
+            public Duration getElapsed() {
+                return Duration.of(1, ChronoUnit.DAYS);
+            }
+        };
+        IndexingProgressView indexingProgressView = new IndexingProgressView(mockIndexingProgress);
+
+        assertThat(indexingProgressView.getElapsed(), is(equalTo("1 day 00:00:00")));
+    }
+
+    @Test
+    void getElapsed_long() {
+        IndexingProgress mockIndexingProgress = new IndexingProgress() {
+            @Override
+            public float getProgress() {
+                return 0.1f;
+            }
+
+            @Override
+            public Duration getElapsed() {
+                return Duration.of(2, ChronoUnit.DAYS)
+                        .plus(3, ChronoUnit.HOURS)
+                        .plus(5, ChronoUnit.MINUTES)
+                        .plus(24, ChronoUnit.SECONDS);
+            }
+        };
+        IndexingProgressView indexingProgressView = new IndexingProgressView(mockIndexingProgress);
+
+        assertThat(indexingProgressView.getElapsed(), is(equalTo("2 days 03:05:24")));
+    }
+
+    @Test
+    void getElapsed_year() {
+        IndexingProgress mockIndexingProgress = new IndexingProgress() {
+            @Override
+            public float getProgress() {
+                return 0.1f;
+            }
+
+            @Override
+            public Duration getElapsed() {
+                return Duration.of(365, ChronoUnit.DAYS)
+                        .plus(3, ChronoUnit.HOURS)
+                        .plus(5, ChronoUnit.MINUTES)
+                        .plus(24, ChronoUnit.SECONDS);
+            }
+        };
+        IndexingProgressView indexingProgressView = new IndexingProgressView(mockIndexingProgress);
+
+        assertThat(indexingProgressView.getElapsed(), is(equalTo("365 days 03:05:24")));
+    }
+
+    @Test
+    void getEstimatedCompletion_unknown() {
+        IndexingProgress mockIndexingProgress = new IndexingProgress() {
+            @Override
+            public float getProgress() {
+                return Float.NaN;
+            }
+
+            @Override
+            public Duration getElapsed() {
+                return Duration.ZERO;
+            }
+
+            @Nonnull
+            @Override
+            public Optional<Duration> getEstimatedCompletion() {
+                return Optional.empty();
+            }
+        };
+        IndexingProgressView indexingProgressView = new IndexingProgressView(mockIndexingProgress);
+
+        assertThat(indexingProgressView.getEstimatedCompletion(), is(equalTo("Unknown")));
+    }
+
+    @Test
+    void getEstimatedCompletion_time() {
+        IndexingProgress mockIndexingProgress = new IndexingProgress() {
+            @Override
+            public float getProgress() {
+                return Float.NaN;
+            }
+
+            @Override
+            public Duration getElapsed() {
+                return Duration.ZERO;
+            }
+
+            @Nonnull
+            @Override
+            public Optional<Duration> getEstimatedCompletion() {
+                return Optional.of(Duration.of(1, ChronoUnit.DAYS).plus(1, ChronoUnit.HOURS));
+            }
+        };
+        IndexingProgressView indexingProgressView = new IndexingProgressView(mockIndexingProgress);
+
+        assertThat(indexingProgressView.getEstimatedCompletion(), is(equalTo("1 day 01:00:00")));
+    }
+
+    @Test
+    void getEstimatedCompletionTime_normal() {
+        Instant tomorrow = Instant.now().plus(1, ChronoUnit.DAYS);
+        IndexingProgress mockIndexingProgress = new IndexingProgress() {
+            @Override
+            public float getProgress() {
+                return Float.NaN;
+            }
+
+            @Override
+            public Duration getElapsed() {
+                return Duration.ZERO;
+            }
+
+            @Nonnull
+            @Override
+            public Optional<Duration> getEstimatedCompletion() {
+                return Optional.of(Duration.between(Instant.now(), tomorrow));
+            }
+        };
+        IndexingProgressView indexingProgressView = new IndexingProgressView(mockIndexingProgress);
+
+        assertThat(indexingProgressView.getEstimatedCompletionTime().toString(), is(equalTo(Date.from(tomorrow).toString())));
+    }
+
+    @Test
+    void getEstimatedCompletionTime_unknown() {
+        IndexingProgress mockIndexingProgress = new IndexingProgress() {
+            @Override
+            public float getProgress() {
+                return Float.NaN;
+            }
+
+            @Override
+            public Duration getElapsed() {
+                return Duration.ZERO;
+            }
+
+            @Nonnull
+            @Override
+            public Optional<Duration> getEstimatedCompletion() {
+                return Optional.empty();
+            }
+        };
+        IndexingProgressView indexingProgressView = new IndexingProgressView(mockIndexingProgress);
+
+        assertThat(indexingProgressView.getEstimatedCompletionTime(), is(nullValue()));
+    }
+}

--- a/alfresco-health-processor-platform/src/testFixtures/java/eu/xenit/alfresco/healthprocessor/indexing/AssertIndexingStrategy.java
+++ b/alfresco-health-processor-platform/src/testFixtures/java/eu/xenit/alfresco/healthprocessor/indexing/AssertIndexingStrategy.java
@@ -19,16 +19,19 @@ public class AssertIndexingStrategy implements IndexingStrategy {
     private RuntimeException toThrow;
     private int numberOfOnStartInvocations;
     private int numberOfGetNextNodeIdsInvocations;
+    private int numberOfRequestedNodes;
 
     @Override
     public void onStart() {
         numberOfOnStartInvocations++;
+        numberOfRequestedNodes = 0;
     }
 
     @Nonnull
     @Override
     public Set<NodeRef> getNextNodeIds(int amount) {
         numberOfGetNextNodeIdsInvocations++;
+        numberOfRequestedNodes+=amount;
         if (toThrow != null) {
             throw toThrow;
         }
@@ -41,6 +44,12 @@ public class AssertIndexingStrategy implements IndexingStrategy {
         }
 
         return ret;
+    }
+
+    @Nonnull
+    @Override
+    public IndexingProgress getIndexingProgress() {
+        return new SimpleIndexingProgress(0, nodeQueue.size(), () -> numberOfRequestedNodes);
     }
 
     public void nextThrow(RuntimeException e) {

--- a/integration-tests/src/test/resources/compose/docker-compose.yml
+++ b/integration-tests/src/test/resources/compose/docker-compose.yml
@@ -17,6 +17,7 @@ services:
       - GLOBAL_eu.xenit.alfresco.healthprocessor.processing.max-batches-per-second=100
       - GLOBAL_eu.xenit.alfresco.healthprocessor.plugin.noop.enabled=true
       - GLOBAL_eu.xenit.alfresco.healthprocessor.reporter.log.summary.enabled=true
+      - GLOBAL_eu.xenit.alfresco.healthprocessor.reporter.log.progress.enabled=true
       - GLOBAL_eu.xenit.alfresco.healthprocessor.reporter.alfred-telemetry.enabled=true
       - GLOBAL_eu.xenit.alfresco.healthprocessor.plugin.content-validation.enabled=true
       - GLOBAL_eu.xenit.alfresco.healthprocessor.plugin.content-validation.properties=cm:content


### PR DESCRIPTION
Currently, it's quite hard to understand the progress of a health-processor cycle: the user has to look at the admin dashboard and interpret the internal state of the indexer:

```
max-txn-id-inclusive: 67138839
next-txn-id: 5600001
```

From this, you can calculate an approximate progress of the indexer by dividing next-txn-id by max-txn-id-inclusive to get a rough percentage.To estimate how long a whole cycle will take, you will have to remember when we started, where we are now (time & percentage) and extrapolate from there to determine how long the cycle will take.

We can make the computer do these things for us and make the admin dashboard more friendly so people looking at it do not need to know internals to know the progress.