### PR TITLE
Export all node health statuses in micrometer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@ Version template:
 * [[#34](https://github.com/xenit-eu/alfresco-health-processor/pull/34)] Solr index validation plugin
 * [[#35](https://github.com/xenit-eu/alfresco-health-processor/pull/35)] Last N transactions indexing strategy
 
+### Fixed
+
+* [[#37]](https://github.com/xenit-eu/alfresco-health-processor/pull/37)]  Export all node health statuses in micrometer
+
 ## [0.4.0] - 2021-07-08
 ### Added
 * Alfresco 7 support

--- a/alfresco-health-processor-platform/src/main/java/eu/xenit/alfresco/healthprocessor/reporter/ReportsService.java
+++ b/alfresco-health-processor-platform/src/main/java/eu/xenit/alfresco/healthprocessor/reporter/ReportsService.java
@@ -6,6 +6,7 @@ import eu.xenit.alfresco.healthprocessor.reporter.api.NodeHealthReport;
 import eu.xenit.alfresco.healthprocessor.reporter.api.NodeHealthStatus;
 import eu.xenit.alfresco.healthprocessor.reporter.api.ProcessorPluginOverview;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -44,8 +45,8 @@ public class ReportsService {
 
         List<ProcessorPluginOverview> overviews = new ArrayList<>();
         pluginClasses.forEach(clazz -> {
-            List<NodeHealthReport> reports = allReports.get(clazz);
-            Map<NodeHealthStatus, Long> stats = allStats.get(clazz);
+            List<NodeHealthReport> reports = allReports.getOrDefault(clazz, Collections.emptyList());
+            Map<NodeHealthStatus, Long> stats = allStats.getOrDefault(clazz, Collections.emptyMap());
             overviews.add(new ProcessorPluginOverview(clazz, stats, reports));
         });
         forEachEnabledReporter(reporter -> reporter.onCycleDone(overviews));

--- a/alfresco-health-processor-platform/src/main/java/eu/xenit/alfresco/healthprocessor/reporter/api/ProcessorPluginOverview.java
+++ b/alfresco-health-processor-platform/src/main/java/eu/xenit/alfresco/healthprocessor/reporter/api/ProcessorPluginOverview.java
@@ -3,13 +3,17 @@ package eu.xenit.alfresco.healthprocessor.reporter.api;
 import eu.xenit.alfresco.healthprocessor.plugins.api.HealthProcessorPlugin;
 import java.util.List;
 import java.util.Map;
+import javax.annotation.Nonnull;
 import lombok.Value;
 
 @Value
 public class ProcessorPluginOverview {
 
+    @Nonnull
     Class<? extends HealthProcessorPlugin> pluginClass;
+    @Nonnull
     Map<NodeHealthStatus, Long> countsByStatus;
+    @Nonnull
     List<NodeHealthReport> reports;
 
 }

--- a/alfresco-health-processor-platform/src/main/java/eu/xenit/alfresco/healthprocessor/reporter/telemetry/AlfredTelemetryHealthReporter.java
+++ b/alfresco-health-processor-platform/src/main/java/eu/xenit/alfresco/healthprocessor/reporter/telemetry/AlfredTelemetryHealthReporter.java
@@ -64,7 +64,7 @@ public class AlfredTelemetryHealthReporter extends SingleReportHealthReporter {
 
     @Override
     protected void processReport(NodeHealthReport report, Class<? extends HealthProcessorPlugin> pluginClass) {
-        if(plugins.add(pluginClass)) {
+        if (plugins.add(pluginClass)) {
             // First time that we see this plugin
             // Create counters for all possible statuses (metrics with tags that are only sometimes present mess with Prometheus)
             for (NodeHealthStatus healthStatus : NodeHealthStatus.values()) {

--- a/alfresco-health-processor-platform/src/test/java/eu/xenit/alfresco/healthprocessor/reporter/telemetry/AlfredTelemetryHealthReporterTest.java
+++ b/alfresco-health-processor-platform/src/test/java/eu/xenit/alfresco/healthprocessor/reporter/telemetry/AlfredTelemetryHealthReporterTest.java
@@ -5,8 +5,8 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 
-import eu.xenit.alfresco.healthprocessor.plugins.NoOpHealthProcessorPlugin;
 import eu.xenit.alfresco.healthprocessor.plugins.AssertHealthProcessorPlugin;
+import eu.xenit.alfresco.healthprocessor.plugins.NoOpHealthProcessorPlugin;
 import eu.xenit.alfresco.healthprocessor.reporter.TestReports;
 import eu.xenit.alfresco.healthprocessor.reporter.telemetry.Constants.Key;
 import eu.xenit.alfresco.healthprocessor.reporter.telemetry.Constants.Tag;
@@ -55,6 +55,7 @@ class AlfredTelemetryHealthReporterTest {
         reporter.processReport(TestReports.healthy(), NoOpHealthProcessorPlugin.class);
 
         assertThat(getReportGaugesValue(null, null), is(equalTo(2d)));
+        assertThat(getReportGaugesValue("UNHEALTHY", null), is(equalTo(0d)));
         assertThat(getReportGaugesValue("HEALTHY", null), is(equalTo(2d)));
         assertThat(getReportGaugesValue("HEALTHY", "AssertHealthProcessorPlugin"), is(equalTo(1d)));
         assertThat(getReportGaugesValue(null, "NoOpHealthProcessorPlugin"), is(equalTo(1d)));


### PR DESCRIPTION
Metrics systems do not all deal well with metrics that are only *sometimes* present.

For example, in prometheus it is very annoying if a certain metric is appearing and disappearing,
because it makes it hard to create decent graphs of it and to create alerts on it.

A metric that has not appeared for some time is regarded as non-existent to prometheus, which can cause inconsistent results, depending on when Alfresco is restarted/a new health processor run is executed.

