### PR TITLE
XENOPS-897 Change response check of SolrIndexValidationHealthProcessorPlugin

### DIFF
--- a/alfresco-health-processor-platform/src/main/java/eu/xenit/alfresco/healthprocessor/fixer/solr/AbstractSolrNodeFixerPlugin.java
+++ b/alfresco-health-processor-platform/src/main/java/eu/xenit/alfresco/healthprocessor/fixer/solr/AbstractSolrNodeFixerPlugin.java
@@ -7,6 +7,7 @@ import eu.xenit.alfresco.healthprocessor.plugins.api.HealthProcessorPlugin;
 import eu.xenit.alfresco.healthprocessor.plugins.solr.NodeIndexHealthReport;
 import eu.xenit.alfresco.healthprocessor.plugins.solr.SolrRequestExecutor;
 import eu.xenit.alfresco.healthprocessor.plugins.solr.SolrRequestExecutor.SolrNodeCommand;
+import eu.xenit.alfresco.healthprocessor.plugins.solr.SolrRequestExecutor.SolrActionResponse;
 import eu.xenit.alfresco.healthprocessor.reporter.api.NodeHealthReport;
 import java.util.HashSet;
 import java.util.Set;
@@ -47,14 +48,14 @@ abstract class AbstractSolrNodeFixerPlugin extends ToggleableHealthFixerPlugin {
                     command,
                     endpointHealthReport.getNodeRefStatus().getNodeRef(),
                     endpointHealthReport.getEndpoint());
-            boolean isSuccessful = solrRequestExecutor.executeAsyncNodeCommand(endpointHealthReport.getEndpoint(),
-                    endpointHealthReport.getNodeRefStatus(), command);
-            if (isSuccessful) {
-                return new NodeFixReport(NodeFixStatus.SUCCEEDED, unhealthyReport,
-                        command + " scheduled on " + endpointHealthReport.getEndpoint());
+            SolrActionResponse solrActionResponse = solrRequestExecutor.executeAsyncNodeCommand(endpointHealthReport.getEndpoint(),
+                            endpointHealthReport.getNodeRefStatus(), command);
+            if (solrActionResponse.isSuccessFull()) {
+                return new NodeFixReport(NodeFixStatus.SUCCEEDED, unhealthyReport, command + " on " +
+                        endpointHealthReport.getEndpoint() + " : " + solrActionResponse.getMessage());
             } else {
-                return new NodeFixReport(NodeFixStatus.FAILED, unhealthyReport,
-                        command + " failed to schedule on " + endpointHealthReport.getEndpoint());
+                return new NodeFixReport(NodeFixStatus.FAILED, unhealthyReport, command + " failed to schedule on " +
+                        endpointHealthReport.getEndpoint() + " : " + solrActionResponse.getMessage());
             }
 
         } catch (Exception e) {

--- a/alfresco-health-processor-platform/src/main/java/eu/xenit/alfresco/healthprocessor/plugins/solr/SolrRequestExecutor.java
+++ b/alfresco-health-processor-platform/src/main/java/eu/xenit/alfresco/healthprocessor/plugins/solr/SolrRequestExecutor.java
@@ -130,22 +130,25 @@ public class SolrRequestExecutor {
         log.trace("Response: {}", response.asText());
         return new SolrActionResponse(response, coreName);
     }
-
-    public class SolrActionResponse {
+    @AllArgsConstructor
+    public static class SolrActionResponse {
         @Getter
         private final boolean successFull;
         @Getter
         private final String message;
 
         public SolrActionResponse(JsonNode response, String coreName) {
-            successFull = response.path("responseHeader").path("status").asInt() == 0;
-            if (!successFull) {
+            boolean isStatusSuccess = response.path("responseHeader").path("status").asInt() == 0;
+            if (!isStatusSuccess) {
+                successFull = false;
                 message = response.path("error").path("msg").asText();
             } else {
                 message = (response.has("action") == true) ?
                         response.path("action").path(coreName).path("status").asText() : "scheduled";
+                successFull = (message.equals("scheduled")) ? true : false;
             }
         }
+
     }
 
 

--- a/alfresco-health-processor-platform/src/main/java/eu/xenit/alfresco/healthprocessor/plugins/solr/SolrRequestExecutor.java
+++ b/alfresco-health-processor-platform/src/main/java/eu/xenit/alfresco/healthprocessor/plugins/solr/SolrRequestExecutor.java
@@ -143,9 +143,9 @@ public class SolrRequestExecutor {
                 successFull = false;
                 message = response.path("error").path("msg").asText();
             } else {
-                message = (response.has("action") == true) ?
+                message = (response.has("action")) ?
                         response.path("action").path(coreName).path("status").asText() : "scheduled";
-                successFull = (message.equals("scheduled")) ? true : false;
+                successFull = message.equals("scheduled");
             }
         }
 

--- a/alfresco-health-processor-platform/src/test/java/eu/xenit/alfresco/healthprocessor/fixer/solr/SolrDuplicateNodeFixerPluginTest.java
+++ b/alfresco-health-processor-platform/src/test/java/eu/xenit/alfresco/healthprocessor/fixer/solr/SolrDuplicateNodeFixerPluginTest.java
@@ -56,9 +56,9 @@ class SolrDuplicateNodeFixerPluginTest {
                 .add(nodeIndexHealthReport);
 
         when(executor.executeAsyncNodeCommand(endpoint, nodeIndexHealthReport.getNodeRefStatus(), SolrNodeCommand.PURGE))
-                .thenReturn(true);
+                .thenReturn(new SolrRequestExecutor.SolrActionResponse(true ,"scheduled"));
         when(executor.executeAsyncNodeCommand(endpoint, nodeIndexHealthReport.getNodeRefStatus(), SolrNodeCommand.REINDEX))
-                .thenReturn(true);
+                .thenReturn(new SolrRequestExecutor.SolrActionResponse(true ,"scheduled"));
 
         Set<NodeFixReport> nodeFixReports = duplicateNodeFixerPlugin.fix(SolrIndexValidationHealthProcessorPlugin.class,
                 Collections.singleton(healthReport));
@@ -95,9 +95,9 @@ class SolrDuplicateNodeFixerPluginTest {
                 .addAll(Arrays.asList(nodeIndexHealthReport1, nodeIndexHealthReport2));
 
         when(executor.executeAsyncNodeCommand(endpoint1, nodeRefStatus, SolrNodeCommand.PURGE))
-                .thenReturn(true);
+                .thenReturn(new SolrRequestExecutor.SolrActionResponse(true ,"scheduled"));
         when(executor.executeAsyncNodeCommand(endpoint1, nodeRefStatus, SolrNodeCommand.REINDEX))
-                .thenReturn(true);
+                .thenReturn(new SolrRequestExecutor.SolrActionResponse(true ,"scheduled"));
 
         Set<NodeFixReport> nodeFixReports = duplicateNodeFixerPlugin.fix(SolrIndexValidationHealthProcessorPlugin.class,
                 Collections.singleton(healthReport));
@@ -133,9 +133,9 @@ class SolrDuplicateNodeFixerPluginTest {
         healthReport2.data(NodeIndexHealthReport.class).add(nodeIndexHealthReport2);
 
         when(executor.executeAsyncNodeCommand(eq(endpoint1), any(), eq(SolrNodeCommand.PURGE)))
-                .thenReturn(true);
+                .thenReturn(new SolrRequestExecutor.SolrActionResponse(true ,"scheduled"));
         when(executor.executeAsyncNodeCommand(eq(endpoint1), any(), eq(SolrNodeCommand.REINDEX)))
-                .thenReturn(true);
+                .thenReturn(new SolrRequestExecutor.SolrActionResponse(true ,"scheduled"));
 
         Set<NodeFixReport> nodeFixReports = duplicateNodeFixerPlugin.fix(SolrIndexValidationHealthProcessorPlugin.class,
                 set(healthReport1, healthReport2));
@@ -163,7 +163,7 @@ class SolrDuplicateNodeFixerPluginTest {
                 .add(nodeIndexHealthReport);
 
         when(executor.executeAsyncNodeCommand(endpoint, nodeIndexHealthReport.getNodeRefStatus(), SolrNodeCommand.PURGE))
-                .thenReturn(false);
+                .thenReturn(new SolrRequestExecutor.SolrActionResponse(false ,"failed"));
 
         Set<NodeFixReport> nodeFixReports = duplicateNodeFixerPlugin.fix(SolrIndexValidationHealthProcessorPlugin.class,
                 Collections.singleton(healthReport));
@@ -190,9 +190,9 @@ class SolrDuplicateNodeFixerPluginTest {
                 .add(nodeIndexHealthReport);
 
         when(executor.executeAsyncNodeCommand(endpoint, nodeIndexHealthReport.getNodeRefStatus(), SolrNodeCommand.PURGE))
-                .thenReturn(true);
+                .thenReturn(new SolrRequestExecutor.SolrActionResponse(true ,"scheduled"));
         when(executor.executeAsyncNodeCommand(endpoint, nodeIndexHealthReport.getNodeRefStatus(), SolrNodeCommand.REINDEX))
-                .thenReturn(false);
+                .thenReturn(new SolrRequestExecutor.SolrActionResponse(false ,"failed"));
 
         Set<NodeFixReport> nodeFixReports = duplicateNodeFixerPlugin.fix(SolrIndexValidationHealthProcessorPlugin.class,
                 Collections.singleton(healthReport));
@@ -248,7 +248,7 @@ class SolrDuplicateNodeFixerPluginTest {
                 .add(nodeIndexHealthReport);
 
         when(executor.executeAsyncNodeCommand(endpoint, nodeIndexHealthReport.getNodeRefStatus(), SolrNodeCommand.PURGE))
-                .thenReturn(true);
+                .thenReturn(new SolrRequestExecutor.SolrActionResponse(true ,"scheduled"));
         when(executor.executeAsyncNodeCommand(endpoint, nodeIndexHealthReport.getNodeRefStatus(), SolrNodeCommand.REINDEX))
                 .thenThrow(new IOException("Something very bad happened"));
 

--- a/alfresco-health-processor-platform/src/test/java/eu/xenit/alfresco/healthprocessor/fixer/solr/SolrMissingNodeFixerPluginTest.java
+++ b/alfresco-health-processor-platform/src/test/java/eu/xenit/alfresco/healthprocessor/fixer/solr/SolrMissingNodeFixerPluginTest.java
@@ -16,6 +16,7 @@ import eu.xenit.alfresco.healthprocessor.plugins.solr.NodeIndexHealthReport.Inde
 import eu.xenit.alfresco.healthprocessor.plugins.solr.SolrIndexValidationHealthProcessorPlugin;
 import eu.xenit.alfresco.healthprocessor.plugins.solr.SolrRequestExecutor;
 import eu.xenit.alfresco.healthprocessor.plugins.solr.SolrRequestExecutor.SolrNodeCommand;
+import eu.xenit.alfresco.healthprocessor.plugins.solr.SolrRequestExecutor.SolrActionResponse;
 import eu.xenit.alfresco.healthprocessor.plugins.solr.endpoint.SearchEndpoint;
 import eu.xenit.alfresco.healthprocessor.reporter.api.NodeHealthReport;
 import eu.xenit.alfresco.healthprocessor.util.TestReports;
@@ -54,7 +55,7 @@ class SolrMissingNodeFixerPluginTest {
                 .add(nodeIndexHealthReport);
 
         when(executor.executeAsyncNodeCommand(endpoint, nodeIndexHealthReport.getNodeRefStatus(), SolrNodeCommand.REINDEX))
-                .thenReturn(true);
+                .thenReturn(new SolrActionResponse(true ,"scheduled"));
 
         Set<NodeFixReport> nodeFixReports = missingNodeFixerPlugin.fix(SolrIndexValidationHealthProcessorPlugin.class,
                 Collections.singleton(healthReport));
@@ -88,7 +89,7 @@ class SolrMissingNodeFixerPluginTest {
                 .addAll(Arrays.asList(nodeIndexHealthReport1, nodeIndexHealthReport2));
 
         when(executor.executeAsyncNodeCommand(endpoint1, nodeRefStatus, SolrNodeCommand.REINDEX))
-                .thenReturn(true);
+                .thenReturn(new SolrActionResponse(true ,"scheduled"));
 
         Set<NodeFixReport> nodeFixReports = missingNodeFixerPlugin.fix(SolrIndexValidationHealthProcessorPlugin.class,
                 Collections.singleton(healthReport));
@@ -122,7 +123,7 @@ class SolrMissingNodeFixerPluginTest {
         healthReport2.data(NodeIndexHealthReport.class).add(nodeIndexHealthReport2);
 
         when(executor.executeAsyncNodeCommand(eq(endpoint1), any(), eq(SolrNodeCommand.REINDEX)))
-                .thenReturn(true);
+                .thenReturn(new SolrActionResponse(true ,"scheduled"));
 
         Set<NodeFixReport> nodeFixReports = missingNodeFixerPlugin.fix(SolrIndexValidationHealthProcessorPlugin.class,
                 set(healthReport1, healthReport2));
@@ -151,7 +152,7 @@ class SolrMissingNodeFixerPluginTest {
 
         when(executor.executeAsyncNodeCommand(endpoint, nodeIndexHealthReport.getNodeRefStatus(),
                 SolrNodeCommand.REINDEX))
-                .thenReturn(false);
+                .thenReturn(new SolrActionResponse(false ,"error"));
 
         Set<NodeFixReport> nodeFixReports = missingNodeFixerPlugin.fix(SolrIndexValidationHealthProcessorPlugin.class,
                 Collections.singleton(healthReport));

--- a/alfresco-health-processor-platform/src/test/java/eu/xenit/alfresco/healthprocessor/plugins/solr/SolrRequestExecutorTest.java
+++ b/alfresco-health-processor-platform/src/test/java/eu/xenit/alfresco/healthprocessor/plugins/solr/SolrRequestExecutorTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.github.paweladamski.httpclientmock.HttpClientMock;
 import eu.xenit.alfresco.healthprocessor.plugins.solr.SolrRequestExecutor.SolrNodeCommand;
+import eu.xenit.alfresco.healthprocessor.plugins.solr.SolrRequestExecutor.SolrActionResponse;
 import eu.xenit.alfresco.healthprocessor.plugins.solr.endpoint.SearchEndpoint;
 import eu.xenit.alfresco.healthprocessor.util.SetUtil;
 import java.io.IOException;
@@ -242,12 +243,36 @@ class SolrRequestExecutorTest {
 
         httpClientMock.onGet("http://nowhere/solr/admin/cores?action=reindex&nodeid=25&wt=json&coreName=index")
                 .doReturnJSON("{"
+                        + "\"responseHeader\":{"
+                        + "\"status\":0,"
+                        + "\"QTime\":0 },"
                         + "\"action\": {"
                         + "\"index\": { \"status\": \"scheduled\" }"
                         + "}"
                         + "}");
+        SolrActionResponse response = solrRequestExecutor.executeAsyncNodeCommand(endpoint,
+                nodeRefStatus, SolrNodeCommand.REINDEX);
+        assertTrue(response.isSuccessFull());
+        assertEquals(response.getMessage(), "scheduled");
+    }
 
-        assertTrue(solrRequestExecutor.executeAsyncNodeCommand(endpoint, nodeRefStatus, SolrNodeCommand.REINDEX));
+    //Solr version prior to 2.0 do not include the action response statuses in their response
+    @Test
+    void performNodeCommandReindexSolrv1x() throws IOException {
+        SearchEndpoint endpoint = new SearchEndpoint(URI.create("http://nowhere/solr/index/"));
+
+        NodeRef.Status nodeRefStatus = randomNodeRefStatus(25L, 8L);
+
+        httpClientMock.onGet("http://nowhere/solr/admin/cores?action=reindex&nodeid=25&wt=json&coreName=index")
+                .doReturnJSON("{"
+                        + "\"responseHeader\":{"
+                        + "\"status\":0,"
+                        + "\"QTime\":0 }"
+                        + "}");
+        SolrActionResponse response = solrRequestExecutor.executeAsyncNodeCommand(endpoint,
+                nodeRefStatus, SolrNodeCommand.REINDEX);
+        assertTrue(response.isSuccessFull());
+        assertEquals(response.getMessage(), "scheduled");
     }
 
     @Test
@@ -258,12 +283,36 @@ class SolrRequestExecutorTest {
 
         httpClientMock.onGet("http://nowhere/solr/admin/cores?action=purge&nodeid=25&wt=json&coreName=some-index")
                 .doReturnJSON("{"
+                        + "\"responseHeader\":{"
+                        + "\"status\":0,"
+                        + "\"QTime\":0 },"
                         + "\"action\": {"
                         + "\"some-index\": { \"status\": \"scheduled\" }"
                         + "}"
                         + "}");
 
-        assertTrue(solrRequestExecutor.executeAsyncNodeCommand(endpoint, nodeRefStatus, SolrNodeCommand.PURGE));
+        SolrActionResponse response = solrRequestExecutor.executeAsyncNodeCommand(endpoint,
+                nodeRefStatus, SolrNodeCommand.PURGE);
+        assertTrue(response.isSuccessFull());
+        assertEquals(response.getMessage(), "scheduled");
+    }
+
+    @Test
+    void performNodeCommandStatusCode500() throws IOException {
+        SearchEndpoint endpoint = new SearchEndpoint(URI.create("http://nowhere/solr/index/"));
+
+        NodeRef.Status nodeRefStatus = randomNodeRefStatus(25L, 8L);
+
+        httpClientMock.onGet("http://nowhere/solr/admin/cores?action=purge&nodeid=25&wt=json&coreName=index")
+                .doReturnJSON("{"
+                        + "\"responseHeader\":{"
+                        + "\"status\":500,"
+                        + "\"QTime\":0 }"
+                        + "}");
+
+        SolrActionResponse response = solrRequestExecutor.executeAsyncNodeCommand(endpoint,
+                nodeRefStatus, SolrNodeCommand.PURGE);
+        assertFalse(response.isSuccessFull());
     }
 
     @Test
@@ -274,11 +323,17 @@ class SolrRequestExecutorTest {
 
         httpClientMock.onGet("http://nowhere/solr/admin/cores?action=purge&nodeid=25&wt=json&coreName=index")
                 .doReturnJSON("{"
+                        + "\"responseHeader\":{"
+                        + "\"status\":0,"
+                        + "\"QTime\":0 },"
                         + "\"action\": {"
                         + "\"index\": { \"status\": \"failed\" }"
                         + "}"
                         + "}");
 
-        assertFalse(solrRequestExecutor.executeAsyncNodeCommand(endpoint, nodeRefStatus, SolrNodeCommand.PURGE));
+        SolrActionResponse response = solrRequestExecutor.executeAsyncNodeCommand(endpoint,
+                nodeRefStatus, SolrNodeCommand.PURGE);
+        assertFalse(response.isSuccessFull());
+        assertEquals(response.getMessage(), "failed");
     }
 }

--- a/alfresco-health-processor-platform/src/test/java/eu/xenit/alfresco/healthprocessor/plugins/solr/SolrRequestExecutorTest.java
+++ b/alfresco-health-processor-platform/src/test/java/eu/xenit/alfresco/healthprocessor/plugins/solr/SolrRequestExecutorTest.java
@@ -253,7 +253,7 @@ class SolrRequestExecutorTest {
         SolrActionResponse response = solrRequestExecutor.executeAsyncNodeCommand(endpoint,
                 nodeRefStatus, SolrNodeCommand.REINDEX);
         assertTrue(response.isSuccessFull());
-        assertEquals(response.getMessage(), "scheduled");
+        assertEquals("scheduled", response.getMessage());
     }
 
     //Solr version prior to 2.0 do not include the action response statuses in their response
@@ -272,7 +272,7 @@ class SolrRequestExecutorTest {
         SolrActionResponse response = solrRequestExecutor.executeAsyncNodeCommand(endpoint,
                 nodeRefStatus, SolrNodeCommand.REINDEX);
         assertTrue(response.isSuccessFull());
-        assertEquals(response.getMessage(), "scheduled");
+        assertEquals("scheduled", response.getMessage());
     }
 
     @Test
@@ -294,7 +294,7 @@ class SolrRequestExecutorTest {
         SolrActionResponse response = solrRequestExecutor.executeAsyncNodeCommand(endpoint,
                 nodeRefStatus, SolrNodeCommand.PURGE);
         assertTrue(response.isSuccessFull());
-        assertEquals(response.getMessage(), "scheduled");
+        assertEquals("scheduled", response.getMessage());
     }
 
     @Test
@@ -334,6 +334,6 @@ class SolrRequestExecutorTest {
         SolrActionResponse response = solrRequestExecutor.executeAsyncNodeCommand(endpoint,
                 nodeRefStatus, SolrNodeCommand.PURGE);
         assertFalse(response.isSuccessFull());
-        assertEquals(response.getMessage(), "failed");
+        assertEquals("failed", response.getMessage());
     }
 }


### PR DESCRIPTION
The response check of SolrIndexValidationHealthProcessorPlugin marked every succesfull Fix as Failed for solr versions lower than 2.0. 
This response did not yet incorporate the action status field.   