### PR TITLE
Add description to api project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,9 +22,18 @@ Version template:
 
 # Alfresco Health Processor Changelog
 
-## [0.5.2] - UNRELEASED
+## [0.5.3] - UNRELEASED
+
+## [0.5.2] - 2021-10-26
+
+### Fixed
+
+* [[#50](https://github.com/xenit-eu/alfresco-health-processor/pull/50)] Add description to api project
+
 
 ## [0.5.1] - 2021-10-25
+
+**This release was not published due to an error**
 
 ### Fixed
 

--- a/alfresco-health-processor-api/build.gradle
+++ b/alfresco-health-processor-api/build.gradle
@@ -5,6 +5,8 @@ plugins {
     id 'io.freefair.javadocs' version '6.2.0'
 }
 
+description = "Java API for extensions for ${rootProject.description}"
+
 java {
     withJavadocJar()
     withSourcesJar()

--- a/alfresco-health-processor-platform/build.gradle
+++ b/alfresco-health-processor-platform/build.gradle
@@ -7,7 +7,7 @@ plugins {
     id 'eu.xenit.amp'
 }
 
-description = "A background processor capable of performing various operations on the nodes in your Alfresco repository, in a batched and controlled manner"
+description = "Alfresco Repository module for ${rootProject.description}"
 
 apply from: "${rootDir}/gradle/internalPlatform.gradle"
 

--- a/build.gradle
+++ b/build.gradle
@@ -6,6 +6,8 @@ plugins {
     id 'org.ajoberstar.reckon' version '0.13.0'
 }
 
+description = "Alfresco Health Processor: A background processor capable of performing various operations on the nodes in your Alfresco repository, in a batched and controlled manner"
+
 sonarqube {
     properties {
         property "sonar.projectKey", "xenit-eu_alfresco-health-processor"


### PR DESCRIPTION
Publishing to maven central requires a project description.
This was missing for the api project, resulting in a failed publication
to maven central.