### PR TITLE
Reindex node instead of node transaction

### DIFF
--- a/alfresco-health-processor-platform/src/main/java/eu/xenit/alfresco/healthprocessor/fixer/solr/SolrMissingNodeFixerPlugin.java
+++ b/alfresco-health-processor-platform/src/main/java/eu/xenit/alfresco/healthprocessor/fixer/solr/SolrMissingNodeFixerPlugin.java
@@ -59,7 +59,7 @@ public class SolrMissingNodeFixerPlugin extends AbstractSolrNodeFixerPlugin {
 
         // Action not yet (successfully) sent
         NodeFixReport nodeFixReport = trySendSolrCommand(unhealthyReport, endpointHealthReport,
-                SolrNodeCommand.REINDEX_TRANSACTION);
+                SolrNodeCommand.REINDEX);
 
         searchEndpointTxCache.put(searchEndpointTxId, nodeFixReport);
         return Collections.singleton(nodeFixReport);


### PR DESCRIPTION
The problem with current implementation is that when the node is reindexed by it's initial transaction, subsequent updates (in other transactions) of that node are not indexed.

By reindexing the complete node, the latest state of that node is requested from alfresco and the current metadata state is returned (without the missing updates that were done).

In an ideal situation, all transactions where the was contained in, should be scheduled for reindexation.