### PR TITLE
Place admin webscript in main context

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-java@v4
         with:
-          java-version: 11
+          java-version: 17
           distribution: temurin
       - name: Test
         run: ./gradlew test
@@ -43,7 +43,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-java@v4
         with:
-          java-version: 11
+          java-version: 17
           distribution: temurin
       - name: Test
         run: ./gradlew :integration-tests:alfresco-${{ matrix.flavour }}-${{ matrix.version }}:integrationTest -Prandom_ports=true
@@ -63,7 +63,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-java@v4
         with:
-          java-version: 11
+          java-version: 17
           distribution: temurin
       - name: Publish
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,17 +8,18 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: actions/setup-java@v1
+      - uses: actions/setup-java@v4
         with:
           java-version: 11
+          distribution: temurin
       - name: Test
         run: ./gradlew test
       - name: Upload reports
         if: ${{ failure() }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: reports-test
           path: alfresco-health-processor-platform/build/reports
@@ -37,17 +38,18 @@ jobs:
         flavour: [ "community" ]
         version: [ "52", "61", "62", "70" ]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: actions/setup-java@v1
+      - uses: actions/setup-java@v4
         with:
           java-version: 11
+          distribution: temurin
       - name: Test
         run: ./gradlew :integration-tests:alfresco-${{ matrix.flavour }}-${{ matrix.version }}:integrationTest -Prandom_ports=true
       - name: Upload reports
         if: ${{ failure() }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: reports-integration-test-${{ matrix.flavour }}-${{ matrix.version }}
           path: integration-tests/alfresco-${{ matrix.flavour }}-${{ matrix.version }}/build/reports
@@ -56,12 +58,13 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ startsWith(github.ref, 'refs/tags/') }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: actions/setup-java@v1
+      - uses: actions/setup-java@v4
         with:
           java-version: 11
+          distribution: temurin
       - name: Publish
         env:
           ORG_GRADLE_PROJECT_signingKey: ${{ secrets.MAVEN_CENTRAL_GPG_KEY }}

--- a/alfresco-health-processor-platform/alfresco-7-upwards/build.gradle
+++ b/alfresco-health-processor-platform/alfresco-7-upwards/build.gradle
@@ -5,13 +5,16 @@ plugins {
 }
 
 java {
-    jar.archiveBaseName = "alfresco-health-processor-platform_alfresco7"
     withJavadocJar()
     withSourcesJar()
 
     toolchain {
         languageVersion = JavaLanguageVersion.of(11)
     }
+}
+
+jar {
+    archiveBaseName = "alfresco-health-processor-platform_alfresco7"
 }
 
 dependencies {

--- a/alfresco-health-processor-platform/build.gradle
+++ b/alfresco-health-processor-platform/build.gradle
@@ -32,11 +32,12 @@ configurations {
 }
 
 java {
-    jar {
-        enabled = false
-    }
     withJavadocJar()
     withSourcesJar()
+}
+
+jar {
+    enabled = false
 }
 
 dependencies {

--- a/alfresco-health-processor-platform/src/main/amp/config/alfresco/module/alfresco-health-processor/module-context.xml
+++ b/alfresco-health-processor-platform/src/main/amp/config/alfresco/module/alfresco-health-processor/module-context.xml
@@ -11,18 +11,23 @@
     </bean>
 
     <!--
-    Proxy required to make Admin Console WebScript available in main Spring context
+    Proxy required to make the ResponseViewRenderer available in main Spring context
     -->
-    <bean id="webscript.org.alfresco.enterprise.repository.admin.support-tools.health-processor.get"
-            class="org.alfresco.repo.management.subsystems.SubsystemProxyFactory">
+    <bean id="eu.xenit.alfresco.healthprocessor.webscripts.console.ResponseViewRenderer"
+        class="org.alfresco.repo.management.subsystems.SubsystemProxyFactory">
         <property name="sourceApplicationContextFactory" ref="HealthProcessor"/>
         <property name="sourceBeanName"
-                value="eu.xenit.alfresco.healthprocessor.webscripts.console.AdminConsoleWebScript"/>
+                value="Admin-Console.ResponseViewRenderer"/>
         <property name="interfaces">
             <list>
-                <value>org.springframework.extensions.webscripts.WebScript</value>
+                <value>eu.xenit.alfresco.healthprocessor.webscripts.console.ResponseViewRenderer</value>
             </list>
         </property>
     </bean>
 
+    <bean id="webscript.org.alfresco.enterprise.repository.admin.support-tools.health-processor.get"
+            class="eu.xenit.alfresco.healthprocessor.webscripts.console.AdminConsoleWebScript"
+            parent="webscript">
+        <constructor-arg ref="eu.xenit.alfresco.healthprocessor.webscripts.console.ResponseViewRenderer"/>
+    </bean>
 </beans>

--- a/alfresco-health-processor-platform/src/main/amp/config/alfresco/subsystems/HealthProcessor/default/webscripts-context.xml
+++ b/alfresco-health-processor-platform/src/main/amp/config/alfresco/subsystems/HealthProcessor/default/webscripts-context.xml
@@ -4,14 +4,8 @@
         xsi:schemaLocation="http://www.springframework.org/schema/beans
 		http://www.springframework.org/schema/beans/spring-beans.xsd">
 
-    <bean id="eu.xenit.alfresco.healthprocessor.webscripts.console.AdminConsoleWebScript"
-            class="eu.xenit.alfresco.healthprocessor.webscripts.console.AdminConsoleWebScript"
-            parent="webscript">
-        <constructor-arg ref="Admin-Console.ResponseViewRenderer"/>
-    </bean>
-
     <bean id="Admin-Console.ResponseViewRenderer"
-            class="eu.xenit.alfresco.healthprocessor.webscripts.console.ResponseViewRenderer"
+            class="eu.xenit.alfresco.healthprocessor.webscripts.console.ResponseViewRendererImpl"
             parent="webscript" autowire="byType">
         <property name="serviceRegistry" ref="ServiceRegistry"/>
     </bean>

--- a/alfresco-health-processor-platform/src/main/java/eu/xenit/alfresco/healthprocessor/webscripts/console/ResponseViewRenderer.java
+++ b/alfresco-health-processor-platform/src/main/java/eu/xenit/alfresco/healthprocessor/webscripts/console/ResponseViewRenderer.java
@@ -1,46 +1,8 @@
 package eu.xenit.alfresco.healthprocessor.webscripts.console;
 
-import eu.xenit.alfresco.healthprocessor.fixer.api.HealthFixerPlugin;
-import eu.xenit.alfresco.healthprocessor.indexing.IndexingConfiguration;
-import eu.xenit.alfresco.healthprocessor.indexing.IndexingStrategy;
-import eu.xenit.alfresco.healthprocessor.plugins.api.HealthProcessorPlugin;
-import eu.xenit.alfresco.healthprocessor.processing.ProcessorService;
-import eu.xenit.alfresco.healthprocessor.reporter.api.HealthReporter;
 import eu.xenit.alfresco.healthprocessor.webscripts.console.model.AdminConsoleResponseView;
-import eu.xenit.alfresco.healthprocessor.webscripts.console.model.ExtensionsView;
-import eu.xenit.alfresco.healthprocessor.webscripts.console.model.IndexingStrategyView;
-import java.util.List;
-import lombok.Setter;
-import org.alfresco.service.ServiceRegistry;
-import org.alfresco.service.cmr.module.ModuleDetails;
 
-@Setter
-public class ResponseViewRenderer {
+public interface ResponseViewRenderer {
 
-    public static final String MODULE_ID = "alfresco-health-processor-platform";
-
-    private ModuleDetails moduleDetails;
-    private ProcessorService processorService;
-    private IndexingConfiguration indexingConfiguration;
-    private IndexingStrategy indexingStrategy;
-    private List<HealthProcessorPlugin> plugins;
-    private List<HealthReporter> reporters;
-    private List<HealthFixerPlugin> fixers;
-
-    @SuppressWarnings("unused")
-    public void setServiceRegistry(ServiceRegistry serviceRegistry) {
-        this.moduleDetails = serviceRegistry.getModuleService().getModule(MODULE_ID);
-    }
-
-    public AdminConsoleResponseView renderView() {
-        return new AdminConsoleResponseView(
-                moduleDetails,
-                processorService.getState().toString(),
-                new IndexingStrategyView(indexingConfiguration, indexingStrategy),
-                new ExtensionsView(plugins),
-                new ExtensionsView(reporters),
-                new ExtensionsView(fixers)
-        );
-    }
-
+    AdminConsoleResponseView renderView();
 }

--- a/alfresco-health-processor-platform/src/main/java/eu/xenit/alfresco/healthprocessor/webscripts/console/ResponseViewRendererImpl.java
+++ b/alfresco-health-processor-platform/src/main/java/eu/xenit/alfresco/healthprocessor/webscripts/console/ResponseViewRendererImpl.java
@@ -1,0 +1,47 @@
+package eu.xenit.alfresco.healthprocessor.webscripts.console;
+
+import eu.xenit.alfresco.healthprocessor.fixer.api.HealthFixerPlugin;
+import eu.xenit.alfresco.healthprocessor.indexing.IndexingConfiguration;
+import eu.xenit.alfresco.healthprocessor.indexing.IndexingStrategy;
+import eu.xenit.alfresco.healthprocessor.plugins.api.HealthProcessorPlugin;
+import eu.xenit.alfresco.healthprocessor.processing.ProcessorService;
+import eu.xenit.alfresco.healthprocessor.reporter.api.HealthReporter;
+import eu.xenit.alfresco.healthprocessor.webscripts.console.model.AdminConsoleResponseView;
+import eu.xenit.alfresco.healthprocessor.webscripts.console.model.ExtensionsView;
+import eu.xenit.alfresco.healthprocessor.webscripts.console.model.IndexingStrategyView;
+import java.util.List;
+import lombok.Setter;
+import org.alfresco.service.ServiceRegistry;
+import org.alfresco.service.cmr.module.ModuleDetails;
+
+@Setter
+public class ResponseViewRendererImpl implements ResponseViewRenderer {
+
+    public static final String MODULE_ID = "alfresco-health-processor-platform";
+
+    private ModuleDetails moduleDetails;
+    private ProcessorService processorService;
+    private IndexingConfiguration indexingConfiguration;
+    private IndexingStrategy indexingStrategy;
+    private List<HealthProcessorPlugin> plugins;
+    private List<HealthReporter> reporters;
+    private List<HealthFixerPlugin> fixers;
+
+    @SuppressWarnings("unused")
+    public void setServiceRegistry(ServiceRegistry serviceRegistry) {
+        this.moduleDetails = serviceRegistry.getModuleService().getModule(MODULE_ID);
+    }
+
+    @Override
+    public AdminConsoleResponseView renderView() {
+        return new AdminConsoleResponseView(
+                moduleDetails,
+                processorService.getState().toString(),
+                new IndexingStrategyView(indexingConfiguration, indexingStrategy),
+                new ExtensionsView(plugins),
+                new ExtensionsView(reporters),
+                new ExtensionsView(fixers)
+        );
+    }
+
+}

--- a/alfresco-health-processor-platform/src/test/java/eu/xenit/alfresco/healthprocessor/webscripts/console/AdminConsoleWebScriptTest.java
+++ b/alfresco-health-processor-platform/src/test/java/eu/xenit/alfresco/healthprocessor/webscripts/console/AdminConsoleWebScriptTest.java
@@ -11,7 +11,7 @@ class AdminConsoleWebScriptTest {
 
     @Test
     void executeImpl() {
-        ResponseViewRenderer renderer = mock(ResponseViewRenderer.class);
+        ResponseViewRenderer renderer = mock(ResponseViewRendererImpl.class);
 
         AdminConsoleWebScript webScript = new AdminConsoleWebScript(renderer);
 

--- a/alfresco-health-processor-platform/src/test/java/eu/xenit/alfresco/healthprocessor/webscripts/console/ResponseViewRendererImplTest.java
+++ b/alfresco-health-processor-platform/src/test/java/eu/xenit/alfresco/healthprocessor/webscripts/console/ResponseViewRendererImplTest.java
@@ -27,13 +27,13 @@ import org.alfresco.repo.module.ModuleVersionNumber;
 import org.alfresco.service.cmr.module.ModuleDetails;
 import org.junit.jupiter.api.Test;
 
-class ResponseViewRendererTest {
+class ResponseViewRendererImplTest {
 
     private static final String VERSION = "0.0.7";
 
     @Test
     void render() {
-        ResponseViewRenderer renderer = new ResponseViewRenderer();
+        ResponseViewRendererImpl renderer = new ResponseViewRendererImpl();
 
         ModuleDetails moduleDetails = mock(ModuleDetails.class);
         when(moduleDetails.getModuleVersionNumber()).thenReturn(new ModuleVersionNumber(VERSION));

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,6 @@ plugins {
     id 'eu.xenit.docker-alfresco' version '5.3.0' apply(false)
     id "org.sonarqube" version "3.3"
     id "org.kordamp.gradle.jacoco" version "0.47.0"
-    id 'org.ajoberstar.reckon' version '0.13.0'
 }
 
 description = "Alfresco Health Processor: A background processor capable of performing various operations on the nodes in your Alfresco repository, in a batched and controlled manner"
@@ -22,11 +21,6 @@ ext {
     alfredTelemetryVersion = '0.6.0'
     micrometerVersion = '1.0.6'
     lombokVersion = '1.18.10'
-}
-
-reckon {
-    scopeFromProp()
-    snapshotFromProp()
 }
 
 subprojects {

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ ext {
     alfrescoVersion = '5.2.f'
     alfredTelemetryVersion = '0.6.0'
     micrometerVersion = '1.0.6'
-    lombokVersion = '1.18.10'
+    lombokVersion = '1.18.36'
 }
 
 subprojects {

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
-    id 'eu.xenit.alfresco' version '1.1.0' apply(false)
-    id 'eu.xenit.docker-alfresco' version '5.3.0' apply(false)
+    id 'eu.xenit.alfresco' version '1.2.0' apply(false)
+    id 'eu.xenit.docker-alfresco' version '5.5.0' apply(false)
     id "org.sonarqube" version "3.3"
     id "org.kordamp.gradle.jacoco" version "0.47.0"
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,7 @@
+plugins {
+    id 'org.ajoberstar.reckon.settings' version '0.19.1'
+}
+
 rootProject.name = 'alfresco-health-processor'
 
 include 'alfresco-health-processor-api'
@@ -9,4 +13,11 @@ def integrationTestVersions = ["52", "61", "62", "70"];
 
 integrationTestVersions.each {version ->
     include ":integration-tests:alfresco-community-${version}"
+}
+
+reckon {
+    defaultInferredScope = 'patch'
+    snapshots()
+    scopeCalc = calcScopeFromProp()
+    stageCalc = calcStageFromProp()
 }


### PR DESCRIPTION
Webscripts should be part of the main context, so the bean is not recreated when the subsystem is restarted.

If the webscript bean is recreated; it would be uninitialized, which results in problems with the webscript registry and the admin console (e.g. NullPointerException when trying to access the webscript)

