### PR TITLE
ALFREDOPS-864: fix broken integration tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ Version template:
 
 # Alfresco Health Processor Changelog
 
+## [0.6.1] - 2025-01-08
+
+### Fixed
+* Fixed a bug that caused the OOTB admin console to crash the health processor web scripts from the integration tests.
+
 ## [0.6.0] - 2025-01-07
 
 ### Added

--- a/alfresco-health-processor-api/src/main/java/eu/xenit/alfresco/healthprocessor/fixer/api/ToggleableHealthFixerPlugin.java
+++ b/alfresco-health-processor-api/src/main/java/eu/xenit/alfresco/healthprocessor/fixer/api/ToggleableHealthFixerPlugin.java
@@ -8,10 +8,8 @@ import lombok.Setter;
  *
  * @since 0.5.0
  */
-public abstract class ToggleableHealthFixerPlugin implements HealthFixerPlugin {
+public interface ToggleableHealthFixerPlugin extends HealthFixerPlugin {
 
-    @Getter
-    @Setter
-    private boolean enabled;
+    void setEnabled(boolean status);
 
 }

--- a/alfresco-health-processor-api/src/main/java/eu/xenit/alfresco/healthprocessor/fixer/api/ToggleableHealthFixerPlugin.java
+++ b/alfresco-health-processor-api/src/main/java/eu/xenit/alfresco/healthprocessor/fixer/api/ToggleableHealthFixerPlugin.java
@@ -1,8 +1,5 @@
 package eu.xenit.alfresco.healthprocessor.fixer.api;
 
-import lombok.Getter;
-import lombok.Setter;
-
 /**
  * {@link HealthFixerPlugin} that already has an <code>enabled</code> property
  *

--- a/alfresco-health-processor-platform/src/main/amp/config/alfresco/subsystems/HealthProcessor/default/plugin-context.xml
+++ b/alfresco-health-processor-platform/src/main/amp/config/alfresco/subsystems/HealthProcessor/default/plugin-context.xml
@@ -66,13 +66,13 @@
     <bean class="eu.xenit.alfresco.healthprocessor.plugins.solr.filter.DeletedNodeFilter" />
 
     <bean id="eu.xenit.alfresco.healthprocessor.fixer.solr.SolrMissingNodeFixerPlugin"
-        class="eu.xenit.alfresco.healthprocessor.fixer.solr.SolrMissingNodeFixerPlugin">
+        class="eu.xenit.alfresco.healthprocessor.fixer.solr.SolrMissingNodeFixerPluginImpl">
         <property name="enabled" value="${eu.xenit.alfresco.healthprocessor.fixer.solr-missing-node.enabled}" />
         <constructor-arg name="solrRequestExecutor"
                 ref="eu.xenit.alfresco.healthprocessor.plugins.solr.SolrRequestExecutor" />
     </bean>
     <bean id="eu.xenit.alfresco.healthprocessor.fixer.solr.SolrDuplicateNodeFixerPlugin"
-            class="eu.xenit.alfresco.healthprocessor.fixer.solr.SolrDuplicateNodeFixerPlugin">
+            class="eu.xenit.alfresco.healthprocessor.fixer.solr.SolrDuplicateNodeFixerPluginImpl">
         <property name="enabled" value="${eu.xenit.alfresco.healthprocessor.fixer.solr-duplicate-node.enabled}" />
         <constructor-arg name="solrRequestExecutor"
                 ref="eu.xenit.alfresco.healthprocessor.plugins.solr.SolrRequestExecutor" />

--- a/alfresco-health-processor-platform/src/main/java/eu/xenit/alfresco/healthprocessor/fixer/solr/AbstractSolrNodeFixerPlugin.java
+++ b/alfresco-health-processor-platform/src/main/java/eu/xenit/alfresco/healthprocessor/fixer/solr/AbstractSolrNodeFixerPlugin.java
@@ -13,13 +13,17 @@ import java.util.HashSet;
 import java.util.Set;
 import javax.annotation.Nonnull;
 import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 
-@AllArgsConstructor
+@RequiredArgsConstructor
 @Slf4j
-abstract class AbstractSolrNodeFixerPlugin extends ToggleableHealthFixerPlugin {
+abstract class AbstractSolrNodeFixerPlugin implements ToggleableHealthFixerPlugin {
 
     private final SolrRequestExecutor solrRequestExecutor;
+    private @Getter @Setter boolean enabled;
 
     @Nonnull
     @Override

--- a/alfresco-health-processor-platform/src/main/java/eu/xenit/alfresco/healthprocessor/fixer/solr/SolrDuplicateNodeFixerPlugin.java
+++ b/alfresco-health-processor-platform/src/main/java/eu/xenit/alfresco/healthprocessor/fixer/solr/SolrDuplicateNodeFixerPlugin.java
@@ -1,42 +1,18 @@
 package eu.xenit.alfresco.healthprocessor.fixer.solr;
 
-import eu.xenit.alfresco.healthprocessor.fixer.api.NodeFixReport;
-import eu.xenit.alfresco.healthprocessor.fixer.api.NodeFixStatus;
-import eu.xenit.alfresco.healthprocessor.plugins.solr.NodeIndexHealthReport;
-import eu.xenit.alfresco.healthprocessor.plugins.solr.NodeIndexHealthReport.IndexHealthStatus;
-import eu.xenit.alfresco.healthprocessor.plugins.solr.SolrRequestExecutor;
-import eu.xenit.alfresco.healthprocessor.plugins.solr.SolrRequestExecutor.SolrNodeCommand;
-import eu.xenit.alfresco.healthprocessor.reporter.api.NodeHealthReport;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Set;
+import eu.xenit.alfresco.healthprocessor.fixer.api.ToggleableHealthFixerPlugin;
 
-public class SolrDuplicateNodeFixerPlugin extends AbstractSolrNodeFixerPlugin {
-
-    public SolrDuplicateNodeFixerPlugin(SolrRequestExecutor solrRequestExecutor) {
-        super(solrRequestExecutor);
-    }
-
-    @Override
-    protected Set<NodeFixReport> handleHealthReport(NodeHealthReport unhealthyReport,
-            NodeIndexHealthReport endpointHealthReport) {
-        if (endpointHealthReport.getHealthStatus() != IndexHealthStatus.DUPLICATE) {
-            return Collections.emptySet();
-        }
-        // When a duplicate node is detected, purge it from the index and reindex it
-        // According to MetadataTracker#maintenance(), purge is processed before reindex
-        // Even if it is executed in the same maintenance cycle.
-        // Ref: https://github.com/Alfresco/SearchServices/blob/e7f05e2f13a709cd28afa3ae6acfd3d0000b22ff/search-services/alfresco-search/src/main/java/org/alfresco/solr/tracker/MetadataTracker.java#L257-L266
-        // Purge has to be done before reindex, else we end up with a broken index which will only be fixed
-        // by a subsequent health processor cycle, which would be unacceptable.
-        Set<NodeFixReport> fixReports = new HashSet<>();
-        NodeFixReport purgeStatus = trySendSolrCommand(unhealthyReport, endpointHealthReport, SolrNodeCommand.PURGE);
-        fixReports.add(purgeStatus);
-        if(purgeStatus.getFixStatus() == NodeFixStatus.SUCCEEDED) {
-            fixReports.add(trySendSolrCommand(unhealthyReport, endpointHealthReport, SolrNodeCommand.REINDEX));
-        }
-
-        return fixReports;
-    }
+/**
+ * <p>
+ * Interface representation of the {@link SolrDuplicateNodeFixerPluginImpl} class.
+ * </p>
+ * <p>
+ * The reason for tbe existence this interface is to allow the {@link org.alfresco.repo.management.subsystems.SubsystemProxyFactory}
+ * to create a proxy of the {@link SolrDuplicateNodeFixerPluginImpl} class from the health processor application context
+ * in the main application context.
+ * This proxy is only used as part of the integration tests from the health processor repo.
+ * </p>
+ */
+public interface SolrDuplicateNodeFixerPlugin extends ToggleableHealthFixerPlugin {
 
 }

--- a/alfresco-health-processor-platform/src/main/java/eu/xenit/alfresco/healthprocessor/fixer/solr/SolrDuplicateNodeFixerPluginImpl.java
+++ b/alfresco-health-processor-platform/src/main/java/eu/xenit/alfresco/healthprocessor/fixer/solr/SolrDuplicateNodeFixerPluginImpl.java
@@ -1,0 +1,42 @@
+package eu.xenit.alfresco.healthprocessor.fixer.solr;
+
+import eu.xenit.alfresco.healthprocessor.fixer.api.NodeFixReport;
+import eu.xenit.alfresco.healthprocessor.fixer.api.NodeFixStatus;
+import eu.xenit.alfresco.healthprocessor.plugins.solr.NodeIndexHealthReport;
+import eu.xenit.alfresco.healthprocessor.plugins.solr.NodeIndexHealthReport.IndexHealthStatus;
+import eu.xenit.alfresco.healthprocessor.plugins.solr.SolrRequestExecutor;
+import eu.xenit.alfresco.healthprocessor.plugins.solr.SolrRequestExecutor.SolrNodeCommand;
+import eu.xenit.alfresco.healthprocessor.reporter.api.NodeHealthReport;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+public class SolrDuplicateNodeFixerPluginImpl extends AbstractSolrNodeFixerPlugin implements SolrDuplicateNodeFixerPlugin {
+
+    public SolrDuplicateNodeFixerPluginImpl(SolrRequestExecutor solrRequestExecutor) {
+        super(solrRequestExecutor);
+    }
+
+    @Override
+    protected Set<NodeFixReport> handleHealthReport(NodeHealthReport unhealthyReport,
+            NodeIndexHealthReport endpointHealthReport) {
+        if (endpointHealthReport.getHealthStatus() != IndexHealthStatus.DUPLICATE) {
+            return Collections.emptySet();
+        }
+        // When a duplicate node is detected, purge it from the index and reindex it
+        // According to MetadataTracker#maintenance(), purge is processed before reindex
+        // Even if it is executed in the same maintenance cycle.
+        // Ref: https://github.com/Alfresco/SearchServices/blob/e7f05e2f13a709cd28afa3ae6acfd3d0000b22ff/search-services/alfresco-search/src/main/java/org/alfresco/solr/tracker/MetadataTracker.java#L257-L266
+        // Purge has to be done before reindex, else we end up with a broken index which will only be fixed
+        // by a subsequent health processor cycle, which would be unacceptable.
+        Set<NodeFixReport> fixReports = new HashSet<>();
+        NodeFixReport purgeStatus = trySendSolrCommand(unhealthyReport, endpointHealthReport, SolrNodeCommand.PURGE);
+        fixReports.add(purgeStatus);
+        if(purgeStatus.getFixStatus() == NodeFixStatus.SUCCEEDED) {
+            fixReports.add(trySendSolrCommand(unhealthyReport, endpointHealthReport, SolrNodeCommand.REINDEX));
+        }
+
+        return fixReports;
+    }
+
+}

--- a/alfresco-health-processor-platform/src/main/java/eu/xenit/alfresco/healthprocessor/fixer/solr/SolrMissingNodeFixerPlugin.java
+++ b/alfresco-health-processor-platform/src/main/java/eu/xenit/alfresco/healthprocessor/fixer/solr/SolrMissingNodeFixerPlugin.java
@@ -1,78 +1,18 @@
 package eu.xenit.alfresco.healthprocessor.fixer.solr;
 
-import eu.xenit.alfresco.healthprocessor.fixer.api.NodeFixReport;
-import eu.xenit.alfresco.healthprocessor.fixer.api.NodeFixStatus;
-import eu.xenit.alfresco.healthprocessor.plugins.api.HealthProcessorPlugin;
-import eu.xenit.alfresco.healthprocessor.plugins.solr.NodeIndexHealthReport;
-import eu.xenit.alfresco.healthprocessor.plugins.solr.NodeIndexHealthReport.IndexHealthStatus;
-import eu.xenit.alfresco.healthprocessor.plugins.solr.SolrRequestExecutor;
-import eu.xenit.alfresco.healthprocessor.plugins.solr.SolrRequestExecutor.SolrNodeCommand;
-import eu.xenit.alfresco.healthprocessor.plugins.solr.endpoint.SearchEndpoint;
-import eu.xenit.alfresco.healthprocessor.reporter.api.NodeHealthReport;
-import lombok.Value;
-import lombok.extern.slf4j.Slf4j;
-import org.alfresco.service.cmr.repository.NodeRef;
+import eu.xenit.alfresco.healthprocessor.fixer.api.ToggleableHealthFixerPlugin;
 
-import javax.annotation.Nonnull;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Set;
-
-@Slf4j
-public class SolrMissingNodeFixerPlugin extends AbstractSolrNodeFixerPlugin {
-    private Map<SearchEndpointTxId, NodeFixReport> searchEndpointTxCache = new HashMap<>();
-
-    public SolrMissingNodeFixerPlugin(SolrRequestExecutor solrRequestExecutor) {
-        super(solrRequestExecutor);
-    }
-
-    @Nonnull
-    @Override
-    public Set<NodeFixReport> fix(Class<? extends HealthProcessorPlugin> pluginClass,
-                                  Set<NodeHealthReport> unhealthyReports) {
-        clearCache();
-        return super.fix(pluginClass, unhealthyReports);
-    }
-
-    @Override
-    protected Set<NodeFixReport> handleHealthReport(NodeHealthReport unhealthyReport,
-            NodeIndexHealthReport endpointHealthReport) {
-        if (endpointHealthReport.getHealthStatus() != IndexHealthStatus.NOT_FOUND) {
-            return Collections.emptySet();
-        }
-
-        NodeRef.Status nodeStatus = endpointHealthReport.getNodeRefStatus();
-        SearchEndpointTxId searchEndpointTxId = new SearchEndpointTxId(endpointHealthReport.getEndpoint(), nodeStatus.getDbTxnId());
-        if (searchEndpointTxCache.containsKey(searchEndpointTxId)) {
-            NodeFixReport cachedNodeFixReport = searchEndpointTxCache.get(searchEndpointTxId);
-            log.trace("We already have a fix report for {}: {}", searchEndpointTxId, cachedNodeFixReport);
-            //If a successful reindex action was already sent for this tx to this endpoint, do not schedule another one
-            if (cachedNodeFixReport.getFixStatus() == NodeFixStatus.SUCCEEDED) {
-                log.trace("Fix for TX of {} has already succeeded, sending existing fix report messages.", unhealthyReport);
-                return Collections.singleton(new NodeFixReport(cachedNodeFixReport.getFixStatus(), unhealthyReport,
-                        cachedNodeFixReport.getMessages()));
-            }
-        }
-
-        log.trace("Performing reindex for {}", searchEndpointTxId);
-
-        // Action not yet (successfully) sent
-        NodeFixReport nodeFixReport = trySendSolrCommand(unhealthyReport, endpointHealthReport,
-                SolrNodeCommand.REINDEX_TRANSACTION);
-
-        searchEndpointTxCache.put(searchEndpointTxId, nodeFixReport);
-        return Collections.singleton(nodeFixReport);
-    }
-
-    @Value
-    public static class SearchEndpointTxId {
-        private final SearchEndpoint searchEndpoint;
-        private final Long txId;
-    }
-
-    private void clearCache() {
-        searchEndpointTxCache.clear();
-    }
+/**
+ * <p>
+ * Interface representation of the {@link SolrMissingNodeFixerPluginImpl} class.
+ * </p>
+ * <p>
+ * The reason for tbe existence this interface is to allow the {@link org.alfresco.repo.management.subsystems.SubsystemProxyFactory}
+ * to create a proxy of the {@link SolrMissingNodeFixerPluginImpl} class from the health processor application context
+ * in the main application context.
+ * This proxy is only used as part of the integration tests from the health processor repo.
+ * </p>
+ */
+public interface SolrMissingNodeFixerPlugin extends ToggleableHealthFixerPlugin {
 
 }

--- a/alfresco-health-processor-platform/src/main/java/eu/xenit/alfresco/healthprocessor/fixer/solr/SolrMissingNodeFixerPluginImpl.java
+++ b/alfresco-health-processor-platform/src/main/java/eu/xenit/alfresco/healthprocessor/fixer/solr/SolrMissingNodeFixerPluginImpl.java
@@ -1,0 +1,79 @@
+package eu.xenit.alfresco.healthprocessor.fixer.solr;
+
+import eu.xenit.alfresco.healthprocessor.fixer.api.NodeFixReport;
+import eu.xenit.alfresco.healthprocessor.fixer.api.NodeFixStatus;
+import eu.xenit.alfresco.healthprocessor.plugins.api.HealthProcessorPlugin;
+import eu.xenit.alfresco.healthprocessor.plugins.solr.NodeIndexHealthReport;
+import eu.xenit.alfresco.healthprocessor.plugins.solr.NodeIndexHealthReport.IndexHealthStatus;
+import eu.xenit.alfresco.healthprocessor.plugins.solr.SolrRequestExecutor;
+import eu.xenit.alfresco.healthprocessor.plugins.solr.SolrRequestExecutor.SolrNodeCommand;
+import eu.xenit.alfresco.healthprocessor.plugins.solr.endpoint.SearchEndpoint;
+import eu.xenit.alfresco.healthprocessor.reporter.api.NodeHealthReport;
+import lombok.Value;
+import lombok.extern.slf4j.Slf4j;
+import org.alfresco.service.cmr.repository.NodeRef;
+
+import javax.annotation.Nonnull;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+@Slf4j
+public class SolrMissingNodeFixerPluginImpl extends AbstractSolrNodeFixerPlugin implements SolrMissingNodeFixerPlugin {
+
+    private Map<SearchEndpointTxId, NodeFixReport> searchEndpointTxCache = new HashMap<>();
+
+    public SolrMissingNodeFixerPluginImpl(SolrRequestExecutor solrRequestExecutor) {
+        super(solrRequestExecutor);
+    }
+
+    @Nonnull
+    @Override
+    public Set<NodeFixReport> fix(Class<? extends HealthProcessorPlugin> pluginClass,
+                                  Set<NodeHealthReport> unhealthyReports) {
+        clearCache();
+        return super.fix(pluginClass, unhealthyReports);
+    }
+
+    @Override
+    protected Set<NodeFixReport> handleHealthReport(NodeHealthReport unhealthyReport,
+            NodeIndexHealthReport endpointHealthReport) {
+        if (endpointHealthReport.getHealthStatus() != IndexHealthStatus.NOT_FOUND) {
+            return Collections.emptySet();
+        }
+
+        NodeRef.Status nodeStatus = endpointHealthReport.getNodeRefStatus();
+        SearchEndpointTxId searchEndpointTxId = new SearchEndpointTxId(endpointHealthReport.getEndpoint(), nodeStatus.getDbTxnId());
+        if (searchEndpointTxCache.containsKey(searchEndpointTxId)) {
+            NodeFixReport cachedNodeFixReport = searchEndpointTxCache.get(searchEndpointTxId);
+            log.trace("We already have a fix report for {}: {}", searchEndpointTxId, cachedNodeFixReport);
+            //If a successful reindex action was already sent for this tx to this endpoint, do not schedule another one
+            if (cachedNodeFixReport.getFixStatus() == NodeFixStatus.SUCCEEDED) {
+                log.trace("Fix for TX of {} has already succeeded, sending existing fix report messages.", unhealthyReport);
+                return Collections.singleton(new NodeFixReport(cachedNodeFixReport.getFixStatus(), unhealthyReport,
+                        cachedNodeFixReport.getMessages()));
+            }
+        }
+
+        log.trace("Performing reindex for {}", searchEndpointTxId);
+
+        // Action not yet (successfully) sent
+        NodeFixReport nodeFixReport = trySendSolrCommand(unhealthyReport, endpointHealthReport,
+                SolrNodeCommand.REINDEX_TRANSACTION);
+
+        searchEndpointTxCache.put(searchEndpointTxId, nodeFixReport);
+        return Collections.singleton(nodeFixReport);
+    }
+
+    @Value
+    public static class SearchEndpointTxId {
+        private final SearchEndpoint searchEndpoint;
+        private final Long txId;
+    }
+
+    private void clearCache() {
+        searchEndpointTxCache.clear();
+    }
+
+}

--- a/alfresco-health-processor-platform/src/test/java/eu/xenit/alfresco/healthprocessor/fixer/solr/SolrDuplicateNodeFixerPluginImplTest.java
+++ b/alfresco-health-processor-platform/src/test/java/eu/xenit/alfresco/healthprocessor/fixer/solr/SolrDuplicateNodeFixerPluginImplTest.java
@@ -32,15 +32,15 @@ import org.junit.jupiter.api.Test;
 import org.mockito.InOrder;
 import org.mockito.Mockito;
 
-class SolrDuplicateNodeFixerPluginTest {
+class SolrDuplicateNodeFixerPluginImplTest {
 
     private SolrRequestExecutor executor;
-    private SolrDuplicateNodeFixerPlugin duplicateNodeFixerPlugin;
+    private SolrDuplicateNodeFixerPluginImpl duplicateNodeFixerPlugin;
 
     @BeforeEach
     void setup() {
         executor = mock(SolrRequestExecutor.class);
-        duplicateNodeFixerPlugin = new SolrDuplicateNodeFixerPlugin(executor);
+        duplicateNodeFixerPlugin = new SolrDuplicateNodeFixerPluginImpl(executor);
     }
 
     @Test

--- a/alfresco-health-processor-platform/src/test/java/eu/xenit/alfresco/healthprocessor/fixer/solr/SolrMissingNodeFixerPluginImplTest.java
+++ b/alfresco-health-processor-platform/src/test/java/eu/xenit/alfresco/healthprocessor/fixer/solr/SolrMissingNodeFixerPluginImplTest.java
@@ -32,15 +32,15 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
-class SolrMissingNodeFixerPluginTest {
+class SolrMissingNodeFixerPluginImplTest {
 
     private SolrRequestExecutor executor;
-    private SolrMissingNodeFixerPlugin missingNodeFixerPlugin;
+    private SolrMissingNodeFixerPluginImpl missingNodeFixerPlugin;
 
     @BeforeEach
     void setup() {
         executor = mock(SolrRequestExecutor.class);
-        missingNodeFixerPlugin = new SolrMissingNodeFixerPlugin(executor);
+        missingNodeFixerPlugin = new SolrMissingNodeFixerPluginImpl(executor);
     }
 
     @Test

--- a/alfresco-health-processor-platform/src/test/java/eu/xenit/alfresco/healthprocessor/webscripts/console/model/CycleProgressViewTest.java
+++ b/alfresco-health-processor-platform/src/test/java/eu/xenit/alfresco/healthprocessor/webscripts/console/model/CycleProgressViewTest.java
@@ -91,7 +91,7 @@ class CycleProgressViewTest {
 
         CycleProgressView indexingProgressView = new CycleProgressView(mockIndexingProgress);
 
-        assertThat(indexingProgressView.getProgress(), is(equalTo("10,00%")));
+        assertThat(indexingProgressView.getProgress().replaceAll(",", "."), is(equalTo("10.00%")));
     }
 
     @Test

--- a/alfresco-health-processor-platform/src/test/java/eu/xenit/alfresco/healthprocessor/webscripts/console/model/CycleProgressViewTest.java
+++ b/alfresco-health-processor-platform/src/test/java/eu/xenit/alfresco/healthprocessor/webscripts/console/model/CycleProgressViewTest.java
@@ -91,7 +91,7 @@ class CycleProgressViewTest {
 
         CycleProgressView indexingProgressView = new CycleProgressView(mockIndexingProgress);
 
-        assertThat(indexingProgressView.getProgress(), is(equalTo("10.00%")));
+        assertThat(indexingProgressView.getProgress(), is(equalTo("10,00%")));
     }
 
     @Test

--- a/integration-tests/src/main/amp/config/alfresco/extension/subsystems/HealthProcessor/default/default/example-extensions-context.xml
+++ b/integration-tests/src/main/amp/config/alfresco/extension/subsystems/HealthProcessor/default/default/example-extensions-context.xml
@@ -4,10 +4,6 @@
         xsi:schemaLocation="http://www.springframework.org/schema/beans
 		http://www.springframework.org/schema/beans/spring-beans.xsd">
 
-    <bean id="eu.xenit.alfresco.healthprocessor.example.ExampleHealthProcessorPlugin"
-            class="eu.xenit.alfresco.healthprocessor.example.ExampleHealthProcessorPlugin">
-        <constructor-arg name="nodeService" ref="NodeService"/>
-        <property name="enabled" value="${eu.xenit.alfresco.healthprocessor.plugin.example.enabled}"/>
-    </bean>
+
 
 </beans>

--- a/integration-tests/src/main/amp/config/alfresco/extension/subsystems/HealthProcessor/default/default/test-webscripts-context.xml
+++ b/integration-tests/src/main/amp/config/alfresco/extension/subsystems/HealthProcessor/default/default/test-webscripts-context.xml
@@ -4,34 +4,5 @@
         xsi:schemaLocation="http://www.springframework.org/schema/beans
 		http://www.springframework.org/schema/beans/spring-beans.xsd">
 
-    <bean id="ExampleExtensionsGetInfoWebScript"
-            class="eu.xenit.alfresco.healthprocessor.example.ExampleExtensionsGetInfoWebScript"
-            parent="webscript">
-        <constructor-arg name="plugin" ref="eu.xenit.alfresco.healthprocessor.example.ExampleHealthProcessorPlugin"/>
-    </bean>
 
-    <bean id="nodeFinder"
-            class="eu.xenit.alfresco.healthprocessor.solr.NodeFinder">
-        <constructor-arg name="nodeService" ref="NodeService" />
-        <constructor-arg name="searchService" ref="SearchService" />
-        <constructor-arg name="namespaceService" ref="NamespaceService" />
-    </bean>
-
-    <bean id="solr.PurgeWebScript"
-        class="eu.xenit.alfresco.healthprocessor.solr.SolrPurgeNodeWebScript"
-        parent="webscript">
-        <constructor-arg name="nodeFinder" ref="nodeFinder" />
-        <constructor-arg name="endpointSelector" ref="eu.xenit.alfresco.healthprocessor.plugins.solr.endpoint.SearchEndpointSelector" />
-        <constructor-arg name="globalProperties" ref="global-properties" />
-    </bean>
-    <bean id="solr.CheckWebScript"
-            class="eu.xenit.alfresco.healthprocessor.solr.SolrCheckNodeWebScript"
-            parent="webscript">
-        <constructor-arg name="nodeFinder" ref="nodeFinder" />
-    </bean>
-
-    <bean id="solr.ConfigureWebScript"
-            class="eu.xenit.alfresco.healthprocessor.solr.SolrConfigureIndexNodeFixerPlugin"
-            parent="webscript" autowire="constructor">
-    </bean>
 </beans>

--- a/integration-tests/src/main/amp/config/alfresco/module/alfresco-health-processor-example/module-context.xml
+++ b/integration-tests/src/main/amp/config/alfresco/module/alfresco-health-processor-example/module-context.xml
@@ -7,45 +7,65 @@
     <!--
         Proxy required to make webscript available in main Spring context
     -->
-    <bean id="webscript.eu.xenit.alfresco.healthprocessor.example.extensions.info.get"
-            class="org.alfresco.repo.management.subsystems.SubsystemProxyFactory">
+
+    <bean id="eu.xenit.alfresco.healthprocessor.plugins.solr.endpoint.SearchEndpointSelector"
+          class="org.alfresco.repo.management.subsystems.SubsystemProxyFactory">
         <property name="sourceApplicationContextFactory" ref="HealthProcessor"/>
-        <property name="sourceBeanName" value="ExampleExtensionsGetInfoWebScript"/>
+        <property name="sourceBeanName" value="eu.xenit.alfresco.healthprocessor.plugins.solr.endpoint.SearchEndpointSelector"/>
         <property name="interfaces">
             <list>
-                <value>org.springframework.extensions.webscripts.WebScript</value>
+                <value>eu.xenit.alfresco.healthprocessor.plugins.solr.endpoint.SearchEndpointSelector</value>
             </list>
         </property>
     </bean>
 
+    <bean id="eu.xenit.alfresco.healthprocessor.fixer.solr.SolrMissingNodeFixerPlugin"
+          class="org.alfresco.repo.management.subsystems.SubsystemProxyFactory">
+        <property name="sourceApplicationContextFactory" ref="HealthProcessor"/>
+        <property name="sourceBeanName" value="eu.xenit.alfresco.healthprocessor.fixer.solr.SolrMissingNodeFixerPlugin"/>
+        <property name="interfaces">
+            <list>
+                <value>eu.xenit.alfresco.healthprocessor.fixer.solr.SolrMissingNodeFixerPlugin</value>
+            </list>
+        </property>
+    </bean>
+
+    <bean id="nodeFinder"
+          class="eu.xenit.alfresco.healthprocessor.solr.NodeFinder">
+        <constructor-arg name="nodeService" ref="NodeService" />
+        <constructor-arg name="searchService" ref="SearchService" />
+        <constructor-arg name="namespaceService" ref="NamespaceService" />
+    </bean>
+
+    <bean id="eu.xenit.alfresco.healthprocessor.example.ExampleHealthProcessorPlugin"
+          class="eu.xenit.alfresco.healthprocessor.example.ExampleHealthProcessorPlugin">
+        <constructor-arg name="nodeService" ref="NodeService"/>
+        <property name="enabled" value="true"/>
+    </bean>
+
+    <bean id="webscript.eu.xenit.alfresco.healthprocessor.example.extensions.info.get"
+          class="eu.xenit.alfresco.healthprocessor.example.ExampleExtensionsGetInfoWebScript"
+          parent="webscript">
+        <constructor-arg name="plugin" ref="eu.xenit.alfresco.healthprocessor.example.ExampleHealthProcessorPlugin"/>
+    </bean>
+
     <bean id="webscript.eu.xenit.alfresco.healthprocessor.solr.purge.get"
-            class="org.alfresco.repo.management.subsystems.SubsystemProxyFactory">
-        <property name="sourceApplicationContextFactory" ref="HealthProcessor"/>
-        <property name="sourceBeanName" value="solr.PurgeWebScript"/>
-        <property name="interfaces">
-            <list>
-                <value>org.springframework.extensions.webscripts.WebScript</value>
-            </list>
-        </property>
+          class="eu.xenit.alfresco.healthprocessor.solr.SolrPurgeNodeWebScript"
+          parent="webscript">
+        <constructor-arg name="nodeFinder" ref="nodeFinder" />
+        <constructor-arg name="endpointSelector" ref="eu.xenit.alfresco.healthprocessor.plugins.solr.endpoint.SearchEndpointSelector" />
+        <constructor-arg name="globalProperties" ref="global-properties" />
     </bean>
+
     <bean id="webscript.eu.xenit.alfresco.healthprocessor.solr.check.get"
-            class="org.alfresco.repo.management.subsystems.SubsystemProxyFactory">
-        <property name="sourceApplicationContextFactory" ref="HealthProcessor"/>
-        <property name="sourceBeanName" value="solr.CheckWebScript"/>
-        <property name="interfaces">
-            <list>
-                <value>org.springframework.extensions.webscripts.WebScript</value>
-            </list>
-        </property>
+          class="eu.xenit.alfresco.healthprocessor.solr.SolrCheckNodeWebScript"
+          parent="webscript">
+        <constructor-arg name="nodeFinder" ref="nodeFinder" />
     </bean>
+
     <bean id="webscript.eu.xenit.alfresco.healthprocessor.solr.configure.get"
-            class="org.alfresco.repo.management.subsystems.SubsystemProxyFactory">
-        <property name="sourceApplicationContextFactory" ref="HealthProcessor"/>
-        <property name="sourceBeanName" value="solr.ConfigureWebScript"/>
-        <property name="interfaces">
-            <list>
-                <value>org.springframework.extensions.webscripts.WebScript</value>
-            </list>
-        </property>
+          class="eu.xenit.alfresco.healthprocessor.solr.SolrConfigureIndexNodeFixerPlugin"
+          parent="webscript" autowire="constructor">
     </bean>
+
 </beans>

--- a/integration-tests/src/main/java/eu/xenit/alfresco/healthprocessor/solr/SolrConfigureIndexNodeFixerPlugin.java
+++ b/integration-tests/src/main/java/eu/xenit/alfresco/healthprocessor/solr/SolrConfigureIndexNodeFixerPlugin.java
@@ -1,7 +1,6 @@
 package eu.xenit.alfresco.healthprocessor.solr;
 
 import eu.xenit.alfresco.healthprocessor.fixer.solr.SolrMissingNodeFixerPlugin;
-import eu.xenit.alfresco.healthprocessor.fixer.solr.SolrMissingNodeFixerPluginImpl;
 import java.io.IOException;
 import org.springframework.extensions.webscripts.AbstractWebScript;
 import org.springframework.extensions.webscripts.WebScriptRequest;

--- a/integration-tests/src/main/java/eu/xenit/alfresco/healthprocessor/solr/SolrConfigureIndexNodeFixerPlugin.java
+++ b/integration-tests/src/main/java/eu/xenit/alfresco/healthprocessor/solr/SolrConfigureIndexNodeFixerPlugin.java
@@ -1,6 +1,7 @@
 package eu.xenit.alfresco.healthprocessor.solr;
 
 import eu.xenit.alfresco.healthprocessor.fixer.solr.SolrMissingNodeFixerPlugin;
+import eu.xenit.alfresco.healthprocessor.fixer.solr.SolrMissingNodeFixerPluginImpl;
 import java.io.IOException;
 import org.springframework.extensions.webscripts.AbstractWebScript;
 import org.springframework.extensions.webscripts.WebScriptRequest;


### PR DESCRIPTION
https://xenitsupport.jira.com/browse/ALFREDOPS-864

Similar to the problem we had with https://github.com/xenit-eu/alfresco-health-processor/pull/59, the web scripts from the integration tests need to be moved to the main application context.

One problem I had while working on this PR was that the web scripts from the integration tests are referring to beans from the health processor application context. While Alfresco provides the `SubsystemProxyFactory` class to circumvent this problem, this only works if you are working with interfaces to work with the proxied beans, which was not possible here. Therefore, the class hierarchy has been slightly altered:

original:
```mermaid
classDiagram
    HealthFixerPlugin <-- ToggleableHealthFixerPlugin
    ToggleableHealthFixerPlugin <|-- AbstractSolrNodeFixerPlugin
    AbstractSolrNodeFixerPlugin <|-- SolrMissingNodeFixerPlugin
    AbstractSolrNodeFixerPlugin <|-- SolrDuplicateNodeFixerPlugin
```

new one:
```mermaid
classDiagram
    HealthFixerPlugin <-- ToggleableHealthFixerPlugin
    ToggleableHealthFixerPlugin <-- SolrMissingNodeFixerPlugin
    ToggleableHealthFixerPlugin <-- SolrDuplicateNodeFixerPlugin

    ToggleableHealthFixerPlugin <-- AbstractSolrNodeFixerPluginImpl
        AbstractSolrNodeFixerPluginImpl <|-- SolrDuplicateNodeFixerPluginImpl
    SolrDuplicateNodeFixerPlugin <-- SolrDuplicateNodeFixerPluginImpl
    AbstractSolrNodeFixerPluginImpl <|-- SolrMissingNodeFixerPluginImpl
    SolrMissingNodeFixerPlugin <-- SolrMissingNodeFixerPluginImpl
```