### PR TITLE
[ALFREDOPS-865] fix broken Sonartype publication

### DIFF
--- a/alfresco-health-processor-platform/build.gradle
+++ b/alfresco-health-processor-platform/build.gradle
@@ -6,7 +6,7 @@ plugins {
     id 'eu.xenit.amp'
 }
 
-//description = "Alfresco Repository module for ${rootProject.description}"
+description = "Alfresco Repository module for ${rootProject.description}"
 
 java {
     withJavadocJar()


### PR DESCRIPTION
https://xenitsupport.jira.com/browse/ALFREDOPS-865

Since the last release of this repo, the description of the alfresco-health-processor-platform has been accidentally removed. The problem is that Sonatype actually requires a description to be present here:

> Invalid POM: /eu/xenit/alfresco/alfresco-health-processor-platform/0.6.0/alfresco-health-processor-platform-0.6.0.pom: Project description missing

Therefore, the description has been added again.